### PR TITLE
useUniform & more Uniform polish

### DIFF
--- a/.changeset/beige-yaks-double.md
+++ b/.changeset/beige-yaks-double.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": patch
+---
+
+Unit values can now be set to `undefined`. This is useful in units that are guaranteed to source their actual value in one of the shader chunks, or through a uniform.

--- a/.changeset/cuddly-pugs-pretend.md
+++ b/.changeset/cuddly-pugs-pretend.md
@@ -1,0 +1,9 @@
+---
+"shader-composer": patch
+---
+
+The `Time` unit now is a constructor, meaning that you need to invoke `Time()` instead of just using `Time` directly. This also means that right now, multiple invocations of `Time()` will create multiple time uniforms that will get updated separately, so it is advised that you create a single instance of this unit and then reuse that in your shader where needed:
+
+```ts
+const time = Time()
+```

--- a/.changeset/curly-shirts-agree.md
+++ b/.changeset/curly-shirts-agree.md
@@ -1,0 +1,9 @@
+---
+"shader-composer": patch
+---
+
+Uniforms now generate their own names, so you can now create a new uniform like this:
+
+```ts
+const uniform = Uniform("vec3", new Vector3())
+```

--- a/.changeset/metal-pandas-shave.md
+++ b/.changeset/metal-pandas-shave.md
@@ -2,7 +2,7 @@
 "shader-composer-r3f": patch
 ---
 
-New hook, `useUniform`. Will create a (randomly-named) uniform of the specified type, and effectfully update its value when the passed value changes. Example:
+New hook, `useUniform`. Will create a uniform of the specified type, and effectfully update its value when the passed value changes. Example:
 
 ```js
 const uniform = useUniform("float", 1)

--- a/.changeset/metal-pandas-shave.md
+++ b/.changeset/metal-pandas-shave.md
@@ -1,0 +1,9 @@
+---
+"shader-composer-r3f": patch
+---
+
+New hook, `useUniform`. Will create a (randomly-named) uniform of the specified type, and effectfully update its value when the passed value changes. Example:
+
+```js
+const uniform = useUniform("float", 1)
+```

--- a/.changeset/stale-parrots-switch.md
+++ b/.changeset/stale-parrots-switch.md
@@ -2,4 +2,9 @@
 "shader-composer": patch
 ---
 
-`Sampler2D` is gone; in its stead, you can now just use a `Uniform` with the `sampler2D` type.
+`Sampler2D` is gone; in its stead, you can now just use a `Uniform` with the `sampler2D` type. Example:
+
+```ts
+const sampler2D = Uniform("sampler2D", texture)
+const tex2d = Texture2D(sampler2D)
+```

--- a/.changeset/stale-parrots-switch.md
+++ b/.changeset/stale-parrots-switch.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": patch
+---
+
+`Sampler2D` is gone; in its stead, you can now just use a `Uniform` with the `sampler2D` type.

--- a/apps/examples/src/App.tsx
+++ b/apps/examples/src/App.tsx
@@ -1,14 +1,9 @@
-import { Suspense } from "react"
 import examples from "./examples"
 import "./r3f-venue/styles.css"
 import { Venue } from "./r3f-venue/Venue"
 
 function App() {
-	return (
-		<Suspense>
-			<Venue examples={examples} />
-		</Suspense>
-	)
+	return <Venue examples={examples} />
 }
 
 export default App

--- a/apps/examples/src/examples/Dissolve.tsx
+++ b/apps/examples/src/examples/Dissolve.tsx
@@ -10,6 +10,7 @@ export default function DissolveExample() {
 	const sphereOpts = useControls("Sphere", { color: "#666" })
 	const dissolveOpts = useControls("Dissolve", {
 		edgeColor: "#0ef",
+		edgeColorIntensity: { value: 2, min: 0, max: 5 },
 		edgeThickness: { value: 0.2, min: 0, max: 1 },
 		scale: { value: 2.5, min: 0, max: 5 },
 		visibility: { value: 0.5, min: 0, max: 1 }
@@ -21,7 +22,7 @@ export default function DissolveExample() {
 	const dissolveScale = useUniform("float", dissolveOpts.scale)
 	const dissolveEdgeColor = useUniform(
 		"vec3",
-		new Color(dissolveOpts.edgeColor).multiplyScalar(10)
+		new Color(dissolveOpts.edgeColor).multiplyScalar(dissolveOpts.edgeColorIntensity)
 	)
 	const dissolveEdgeThickness = useUniform("float", dissolveOpts.edgeThickness)
 

--- a/apps/examples/src/examples/Dissolve.tsx
+++ b/apps/examples/src/examples/Dissolve.tsx
@@ -19,7 +19,10 @@ export default function DissolveExample() {
 	const sphereColor = useUniform("vec3", new Color(sphereOpts.color))
 	const dissolveVisibility = useUniform("float", dissolveOpts.visibility)
 	const dissolveScale = useUniform("float", dissolveOpts.scale)
-	const dissolveEdgeColor = useUniform("vec3", new Color(dissolveOpts.edgeColor))
+	const dissolveEdgeColor = useUniform(
+		"vec3",
+		new Color(dissolveOpts.edgeColor).multiplyScalar(10)
+	)
 	const dissolveEdgeThickness = useUniform("float", dissolveOpts.edgeThickness)
 
 	/* Shader */

--- a/apps/examples/src/examples/Dissolve.tsx
+++ b/apps/examples/src/examples/Dissolve.tsx
@@ -2,12 +2,13 @@ import { useFrame } from "@react-three/fiber"
 import { useControls } from "leva"
 import { useMemo } from "react"
 import { CustomShaderMaterialMaster, Mix, pipe, Uniform } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { useShader, useUniform } from "shader-composer-r3f"
 import { Dissolve } from "shader-composer-toybox"
 import { Color, DoubleSide, MeshPhysicalMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 
 export default function DissolveExample() {
+	/* Leva */
 	const sphereOpts = useControls("Sphere", { color: "#666" })
 	const dissolveOpts = useControls("Dissolve", {
 		edgeColor: "#0ef",
@@ -16,45 +17,24 @@ export default function DissolveExample() {
 		visibility: { value: 0.5, min: 0, max: 1 }
 	})
 
-	const blackboard = useMemo(
-		() => ({
-			sphere: {
-				color: Uniform("vec3", "u_sphereColor", new Color(sphereOpts.color))
-			},
-			dissolve: {
-				visibility: Uniform("float", "u_visibility", dissolveOpts.visibility),
-				scale: Uniform("float", "u_scale", dissolveOpts.scale),
-				edgeColor: Uniform("vec3", "u_dissolveColor", new Color(dissolveOpts.edgeColor)),
-				edgeThickness: Uniform("float", "u_edgeThickness", dissolveOpts.edgeThickness)
-			}
-		}),
-		[]
-	)
+	/* Uniforms */
+	const sphereColor = useUniform("vec3", new Color(sphereOpts.color))
+	const dissolveVisibility = useUniform("float", dissolveOpts.visibility)
+	const dissolveScale = useUniform("float", dissolveOpts.scale)
+	const dissolveEdgeColor = useUniform("vec3", new Color(dissolveOpts.edgeColor))
+	const dissolveEdgeThickness = useUniform("float", dissolveOpts.edgeThickness)
 
+	/* Shader */
 	const shader = useShader(() => {
-		const dissolve = Dissolve(
-			blackboard.dissolve.visibility,
-			blackboard.dissolve.scale,
-			blackboard.dissolve.edgeThickness
-		)
+		const dissolve = Dissolve(dissolveVisibility, dissolveScale, dissolveEdgeThickness)
 
 		return CustomShaderMaterialMaster({
-			diffuseColor: pipe(blackboard.sphere.color, (v) =>
-				Mix(v, blackboard.dissolve.edgeColor, dissolve.edge)
-			),
+			diffuseColor: pipe(sphereColor, (v) => Mix(v, dissolveEdgeColor, dissolve.edge)),
 			alpha: dissolve.alpha
 		})
 	}, [])
 
-	/* TODO: Maybe shader-composer-r3f can provide some glue for this? */
-	useFrame(() => {
-		blackboard.sphere.color.value.set(sphereOpts.color)
-		blackboard.dissolve.edgeColor.value.set(dissolveOpts.edgeColor)
-		blackboard.dissolve.edgeThickness.value = dissolveOpts.edgeThickness
-		blackboard.dissolve.visibility.value = dissolveOpts.visibility
-		blackboard.dissolve.scale.value = dissolveOpts.scale
-	})
-
+	/* Scene Object */
 	return (
 		<mesh>
 			<icosahedronGeometry args={[1, 10]} />

--- a/apps/examples/src/examples/Dissolve.tsx
+++ b/apps/examples/src/examples/Dissolve.tsx
@@ -1,7 +1,5 @@
-import { useFrame } from "@react-three/fiber"
 import { useControls } from "leva"
-import { useMemo } from "react"
-import { CustomShaderMaterialMaster, Mix, pipe, Uniform } from "shader-composer"
+import { CustomShaderMaterialMaster, Mix, pipe } from "shader-composer"
 import { useShader, useUniform } from "shader-composer-r3f"
 import { Dissolve } from "shader-composer-toybox"
 import { Color, DoubleSide, MeshPhysicalMaterial } from "three"

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -37,6 +37,8 @@ export default function HelloWorld() {
 		})
 	}, [])
 
+	console.log(shader.vertexShader)
+
 	return (
 		<mesh>
 			<sphereGeometry />

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -24,14 +24,16 @@ export default function HelloWorld() {
 	const color2 = useUniform("vec3", new Color(leva.color2))
 
 	const shader = useShader(() => {
+		const time = Time()
+
 		return ShaderMaterialMaster({
 			color: pipe(
 				color1,
-				(v) => Mix(v, color2, Remap(Sin(Time), -1, 1, 0, 1)),
+				(v) => Mix(v, color2, Remap(Sin(time), -1, 1, 0, 1)),
 				(v) => Add(v, Fresnel())
 			),
 
-			position: $`${VertexPosition} * (1.0 + sin(${Time} + ${VertexPosition}.y * 2.0) * 0.2)`
+			position: $`${VertexPosition} * (1.0 + sin(${time} + ${VertexPosition}.y * 2.0) * 0.2)`
 		})
 	}, [])
 

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -15,24 +15,25 @@ import { useShader, useUniform } from "shader-composer-r3f"
 import { Color } from "three"
 
 export default function HelloWorld() {
-	const leva = useControls("Uniforms", { color1: "#bc23c2", color2: "#c7be13" })
+	const leva = useControls("Uniforms", {
+		color1: "#bc23c2",
+		color2: "#c7be13"
+	})
 
 	const color1 = useUniform("vec3", new Color(leva.color1))
 	const color2 = useUniform("vec3", new Color(leva.color2))
 
-	const shader = useShader(
-		() =>
-			ShaderMaterialMaster({
-				color: pipe(
-					color1,
-					(v) => Mix(v, color2, Remap(Sin(Time), -1, 1, 0, 1)),
-					(v) => Add(v, Fresnel())
-				),
+	const shader = useShader(() => {
+		return ShaderMaterialMaster({
+			color: pipe(
+				color1,
+				(v) => Mix(v, color2, Remap(Sin(Time), -1, 1, 0, 1)),
+				(v) => Add(v, Fresnel())
+			),
 
-				position: $`${VertexPosition} * (1.0 + sin(${Time} + ${VertexPosition}.y * 2.0) * 0.2)`
-			}),
-		[]
-	)
+			position: $`${VertexPosition} * (1.0 + sin(${Time} + ${VertexPosition}.y * 2.0) * 0.2)`
+		})
+	}, [])
 
 	return (
 		<mesh>

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -1,5 +1,4 @@
 import { useControls } from "leva"
-import { useEffect, useMemo } from "react"
 import {
 	$,
 	Add,
@@ -10,29 +9,23 @@ import {
 	ShaderMaterialMaster,
 	Sin,
 	Time,
-	Uniform,
 	VertexPosition
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { useShader, useUniform } from "shader-composer-r3f"
 import { Color } from "three"
 
 export default function HelloWorld() {
 	const leva = useControls("Uniforms", { color1: "hotpink", color2: "white" })
 
-	const blackboard = useMemo(
-		() => ({
-			color1: Uniform("vec3", "u_color1", new Color(leva.color1)) /* Set initial value */,
-			color2: Uniform("vec3", "u_color2", new Color(leva.color2))
-		}),
-		[]
-	)
+	const color1 = useUniform("vec3", new Color(leva.color1))
+	const color2 = useUniform("vec3", new Color(leva.color2))
 
 	const shader = useShader(
 		() =>
 			ShaderMaterialMaster({
 				color: pipe(
-					blackboard.color1,
-					(v) => Mix(v, blackboard.color2, Remap(Sin(Time), -1, 1, 0, 1)),
+					color1,
+					(v) => Mix(v, color2, Remap(Sin(Time), -1, 1, 0, 1)),
 					(v) => Add(v, Fresnel())
 				),
 
@@ -40,16 +33,6 @@ export default function HelloWorld() {
 			}),
 		[]
 	)
-
-	useEffect(() => {
-		/* Interact with uniform value */
-		blackboard.color1.value.set(leva.color1)
-	}, [leva.color1])
-
-	useEffect(() => {
-		/* Or replace it wholesale */
-		blackboard.color2.value = new Color(leva.color2)
-	}, [leva.color2])
 
 	return (
 		<mesh>

--- a/apps/examples/src/examples/Planet.tsx
+++ b/apps/examples/src/examples/Planet.tsx
@@ -48,7 +48,7 @@ function Planet() {
 		)
 
 		const water = pipe(
-			Time,
+			Time(),
 			(v) => Add(v, SplitVector3(VertexPosition)[1]),
 			(v) => Sin(v),
 			(v) => Mul(v, 0.008),
@@ -87,14 +87,16 @@ function Planet() {
 
 function Atmosphere() {
 	const shader = useShader(() => {
+		const time = Time()
+
 		const cloudSpeed = 0.02
 		const cloudThreshold = 0.5
 		const cloudDensity = 0.9
 		const atmosphereDensity = 0.05
 
 		const cloudNoise = Add(
-			getNoise(0.5, 1, Mul(Time, cloudSpeed)),
-			getNoise(0.2, 1, Mul(Time, cloudSpeed * -0.5))
+			getNoise(0.5, 1, Mul(time, cloudSpeed)),
+			getNoise(0.2, 1, Mul(time, cloudSpeed * -0.5))
 		)
 
 		const clouds = pipe(

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -8,6 +8,7 @@ import {
 	Texture2D,
 	TilingUV,
 	Time,
+	Uniform,
 	UV,
 	vec2
 } from "shader-composer"
@@ -23,7 +24,7 @@ export default function Playground() {
 		const offset = vec2(Mul(Time, 0.05), 0)
 
 		/* Create a texture sampler */
-		const sampler2D = Sampler2D("u_texture", texture)
+		const sampler2D = Uniform("sampler2D", "u_texture2", texture)
 
 		/* Get the texture information for the current fragment */
 		const tex2d = Texture2D(sampler2D, TilingUV(UV, vec2(2, 1), offset))
@@ -36,6 +37,8 @@ export default function Playground() {
 			alpha: Add(Fresnel(), 0.1)
 		})
 	})
+
+	console.log(shader.fragmentShader)
 
 	return (
 		<mesh>

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -23,7 +23,7 @@ export default function Playground() {
 		const offset = vec2(Mul(Time(), 0.05), 0)
 
 		/* Create a texture sampler */
-		const sampler2D = Uniform("sampler2D", texture, "u_texture2")
+		const sampler2D = Uniform("sampler2D", texture)
 
 		/* Get the texture information for the current fragment */
 		const tex2d = Texture2D(sampler2D, TilingUV(UV, vec2(2, 1), offset))

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react"
 import {
 	$,
 	Add,
@@ -13,18 +12,23 @@ import {
 	vec2
 } from "shader-composer"
 import { useShader } from "shader-composer-r3f"
-import { Color, MeshStandardMaterial, Vector2 } from "three"
+import { Color, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { useRepeatingTexture } from "./helpers"
 
 export default function Playground() {
 	const texture = useRepeatingTexture("/textures/hexgrid.jpg")
 
-	const { uniforms, ...shader } = useShader(() => {
+	const shader = useShader(() => {
 		const offset = vec2(Mul(Time, 0.05), 0)
 
-		const tex2d = Texture2D(Sampler2D("u_texture"), TilingUV(UV, vec2(2, 1), offset))
+		/* Create a texture sampler */
+		const sampler2D = Sampler2D("u_texture", texture)
 
+		/* Get the texture information for the current fragment */
+		const tex2d = Texture2D(sampler2D, TilingUV(UV, vec2(2, 1), offset))
+
+		/* Define a color to tint the texture with */
 		const color = new Color("hotpink")
 
 		return CustomShaderMaterialMaster({
@@ -33,23 +37,10 @@ export default function Playground() {
 		})
 	})
 
-	const myUniforms = useMemo(
-		() => ({
-			...uniforms,
-			u_texture: { value: texture }
-		}),
-		[uniforms]
-	)
-
 	return (
 		<mesh>
 			<icosahedronGeometry args={[1, 3]} />
-			<CustomShaderMaterial
-				baseMaterial={MeshStandardMaterial}
-				uniforms={myUniforms}
-				{...shader}
-				transparent
-			/>
+			<CustomShaderMaterial baseMaterial={MeshStandardMaterial} {...shader} transparent />
 		</mesh>
 	)
 }

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -4,7 +4,6 @@ import {
 	CustomShaderMaterialMaster,
 	Fresnel,
 	Mul,
-	Sampler2D,
 	Texture2D,
 	TilingUV,
 	Time,

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -23,7 +23,7 @@ export default function Playground() {
 		const offset = vec2(Mul(Time(), 0.05), 0)
 
 		/* Create a texture sampler */
-		const sampler2D = Uniform({ type: "sampler2D", value: texture }, "u_texture2")
+		const sampler2D = Uniform("sampler2D", texture, "u_texture2")
 
 		/* Get the texture information for the current fragment */
 		const tex2d = Texture2D(sampler2D, TilingUV(UV, vec2(2, 1), offset))

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -20,10 +20,10 @@ export default function Playground() {
 	const texture = useRepeatingTexture("/textures/hexgrid.jpg")
 
 	const shader = useShader(() => {
-		const offset = vec2(Mul(Time, 0.05), 0)
+		const offset = vec2(Mul(Time(), 0.05), 0)
 
 		/* Create a texture sampler */
-		const sampler2D = Uniform("sampler2D", "u_texture2", texture)
+		const sampler2D = Uniform({ type: "sampler2D", value: texture }, "u_texture2")
 
 		/* Get the texture information for the current fragment */
 		const tex2d = Texture2D(sampler2D, TilingUV(UV, vec2(2, 1), offset))

--- a/apps/examples/src/examples/Water.tsx
+++ b/apps/examples/src/examples/Water.tsx
@@ -29,7 +29,7 @@ function Water() {
 			const xy = vec2(x, z)
 
 			const fbm = NormalizeNoise(
-				FBMNoise(vec2(Add(x, Time), z), {
+				FBMNoise(vec2(Add(x, Time()), z), {
 					seed: Math.random(),
 					persistance: 2.2,
 					lacunarity: 1.3,

--- a/apps/examples/src/examples/Water.tsx
+++ b/apps/examples/src/examples/Water.tsx
@@ -23,6 +23,7 @@ const NormalizeNoise = (v: Value<"float">) => Remap(v, -1, 1, 0, 1)
 function Water() {
 	const shader = useShader(() => {
 		const diffuseColor = new Color("#acd")
+		const time = Time()
 
 		const { position, normal } = ModifyVertex(VertexPosition, VertexNormal, (v) => {
 			const [x, y, z] = SplitVector3(v)
@@ -43,10 +44,10 @@ function Water() {
 
 			return pipe(
 				v,
-				(v) => Add(v, Mul(GerstnerWave(xy, vec2(1, 1), 0.5, 20.0), 0.8)),
-				(v) => Add(v, Mul(GerstnerWave(xy, vec2(0.2, 1), 0.2, 10), 0.8)),
-				(v) => Add(v, Mul(GerstnerWave(xy, vec2(0, -1), 0.2, 5), 0.5)),
-				(v) => Add(v, Mul(GerstnerWave(xy, vec2(1, 1), 0.2, 8), 0.3)),
+				(v) => Add(v, Mul(GerstnerWave(xy, vec2(1, 1), 0.5, 20.0, time), 0.8)),
+				(v) => Add(v, Mul(GerstnerWave(xy, vec2(0.2, 1), 0.2, 10, time), 0.8)),
+				(v) => Add(v, Mul(GerstnerWave(xy, vec2(0, -1), 0.2, 5, time), 0.5)),
+				(v) => Add(v, Mul(GerstnerWave(xy, vec2(1, 1), 0.2, 8, time), 0.3)),
 				(v) => Add(v, Mul(vec3(0, 0.005, 0), fbm))
 			)
 		})

--- a/apps/examples/src/r3f-venue/PostProcessing.tsx
+++ b/apps/examples/src/r3f-venue/PostProcessing.tsx
@@ -4,7 +4,6 @@ import {
 	Effect,
 	EffectComposer,
 	EffectPass,
-	FXAAEffect,
 	Pass,
 	RenderPass,
 	SelectiveBloomEffect,

--- a/apps/examples/src/r3f-venue/PostProcessing.tsx
+++ b/apps/examples/src/r3f-venue/PostProcessing.tsx
@@ -46,11 +46,18 @@ export const PostProcessing = () => {
 		const effect = new SelectiveBloomEffect(scene, camera, {
 			blendFunction: BlendFunction.ADD,
 			mipmapBlur: true,
-			luminanceThreshold: 0.95,
-			luminanceSmoothing: 0.3,
+			luminanceThreshold: 0.9,
+			luminanceSmoothing: 0.5,
 			intensity: 4
 		} as any)
+
+		/*
+		This effect is designed to only bloom selected objects. We're not
+		interested in that, so let's "invert" it -- making all objects
+		selected by default!
+		*/
 		effect.inverted = true
+
 		return effect
 	}, [scene, camera])
 

--- a/apps/examples/src/r3f-venue/Venue.tsx
+++ b/apps/examples/src/r3f-venue/Venue.tsx
@@ -2,7 +2,7 @@ import { Environment, OrbitControls, PerspectiveCamera } from "@react-three/drei
 import { Canvas, useFrame } from "@react-three/fiber"
 import { Perf } from "r3f-perf"
 import { FC, ReactNode, Suspense, useRef } from "react"
-import { Mesh } from "three"
+import { LinearEncoding, Mesh, sRGBEncoding } from "three"
 import { Link, useRoute } from "wouter"
 import { PostProcessing } from "./PostProcessing"
 import Stage from "./Stage"
@@ -53,7 +53,16 @@ export const Venue: FC<{
 	return (
 		<>
 			{examples && <Navigation examples={examples} />}
-			<Canvas>
+			<Canvas
+				flat
+				gl={{
+					powerPreference: "high-performance",
+					alpha: false,
+					depth: true,
+					stencil: false,
+					antialias: false
+				}}
+			>
 				<Environment preset="sunset" />
 				<fogExp2 args={["#000", 0.03]} attach="fog" />
 				<PerspectiveCamera position={[0, 0, 5]} makeDefault />

--- a/apps/examples/src/r3f-venue/Venue.tsx
+++ b/apps/examples/src/r3f-venue/Venue.tsx
@@ -2,7 +2,7 @@ import { Environment, OrbitControls, PerspectiveCamera } from "@react-three/drei
 import { Canvas, useFrame } from "@react-three/fiber"
 import { Perf } from "r3f-perf"
 import { FC, ReactNode, Suspense, useRef } from "react"
-import { LinearEncoding, Mesh, sRGBEncoding } from "three"
+import { Mesh } from "three"
 import { Link, useRoute } from "wouter"
 import { PostProcessing } from "./PostProcessing"
 import Stage from "./Stage"

--- a/apps/examples/src/r3f-venue/Venue.tsx
+++ b/apps/examples/src/r3f-venue/Venue.tsx
@@ -63,28 +63,30 @@ export const Venue: FC<{
 					antialias: false
 				}}
 			>
-				<Environment preset="sunset" />
-				<fogExp2 args={["#000", 0.03]} attach="fog" />
-				<PerspectiveCamera position={[0, 0, 5]} makeDefault />
-				<PostProcessing />
+				<Suspense>
+					<Environment preset="sunset" />
+					<fogExp2 args={["#000", 0.03]} attach="fog" />
+					<PerspectiveCamera position={[0, 0, 5]} makeDefault />
+					<PostProcessing />
 
-				<OrbitControls
-					makeDefault
-					maxDistance={10}
-					minDistance={3}
-					minPolarAngle={Math.PI * 0.25}
-					maxPolarAngle={Math.PI * 0.75}
-				/>
+					<OrbitControls
+						makeDefault
+						maxDistance={10}
+						minDistance={3}
+						minPolarAngle={Math.PI * 0.25}
+						maxPolarAngle={Math.PI * 0.75}
+					/>
 
-				{performance && <Perf position="bottom-right" />}
+					{performance && <Perf position="bottom-right" />}
 
-				<Stage />
+					<Stage />
 
-				<Suspense fallback={<Spinner />}>
-					{examples && <Example examples={examples} />}
+					<Suspense fallback={<Spinner />}>
+						{examples && <Example examples={examples} />}
+					</Suspense>
+
+					{children}
 				</Suspense>
-
-				{children}
 			</Canvas>
 		</>
 	)

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -1,6 +1,6 @@
-import { compileShader, GLSLType, JSTypes, Uniform, Unit } from "shader-composer"
-import { useLayoutEffect, useMemo } from "react"
 import { useFrame } from "@react-three/fiber"
+import { useLayoutEffect, useMemo } from "react"
+import { compileShader, GLSLType, JSTypes, Uniform, Unit } from "shader-composer"
 
 export const useShader = (ctor: () => Unit, deps?: any) => {
 	const [shader, update] = useMemo(() => compileShader(ctor()), deps)
@@ -11,7 +11,7 @@ export const useShader = (ctor: () => Unit, deps?: any) => {
 export const useUniform = <T extends GLSLType>(type: T, value: JSTypes[T]) => {
 	const uniform = useMemo(() => {
 		const name = `u_${Math.floor(Math.random() * 10000)}`
-		return Uniform({ type, value }, name)
+		return Uniform(type, value, name)
 	}, [])
 
 	useLayoutEffect(() => {

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -8,9 +8,12 @@ export const useShader = (ctor: () => Unit, deps?: any) => {
 	return shader
 }
 
-export const useUniform = <T extends GLSLType>(type: T, value: JSTypes[T]) => {
+export const useUniform = <T extends GLSLType>(
+	type: T,
+	value: JSTypes[T],
+	name?: string
+) => {
 	const uniform = useMemo(() => {
-		const name = `u_${Math.floor(Math.random() * 10000)}`
 		return Uniform(type, value, name)
 	}, [])
 

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -1,9 +1,22 @@
-import { compileShader, Unit } from "shader-composer"
-import { useMemo } from "react"
+import { compileShader, GLSLType, JSTypes, Uniform, Unit } from "shader-composer"
+import { useLayoutEffect, useMemo } from "react"
 import { useFrame } from "@react-three/fiber"
 
 export const useShader = (ctor: () => Unit, deps?: any) => {
 	const [shader, update] = useMemo(() => compileShader(ctor()), deps)
 	useFrame((_, dt) => update(dt))
 	return shader
+}
+
+export const useUniform = <T extends GLSLType>(type: T, value: JSTypes[T]) => {
+	const uniform = useMemo(() => {
+		const name = `u_${Math.floor(Math.random() * 10000)}`
+		return Uniform(type, name, value)
+	}, [])
+
+	useLayoutEffect(() => {
+		uniform.value = value
+	}, [value])
+
+	return uniform
 }

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -8,13 +8,9 @@ export const useShader = (ctor: () => Unit, deps?: any) => {
 	return shader
 }
 
-export const useUniform = <T extends GLSLType>(
-	type: T,
-	value: JSTypes[T],
-	name?: string
-) => {
+export const useUniform = <T extends GLSLType>(type: T, value: JSTypes[T]) => {
 	const uniform = useMemo(() => {
-		return Uniform(type, value, name)
+		return Uniform(type, value)
 	}, [])
 
 	useLayoutEffect(() => {

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -11,7 +11,7 @@ export const useShader = (ctor: () => Unit, deps?: any) => {
 export const useUniform = <T extends GLSLType>(type: T, value: JSTypes[T]) => {
 	const uniform = useMemo(() => {
 		const name = `u_${Math.floor(Math.random() * 10000)}`
-		return Uniform(type, name, value)
+		return Uniform({ type, value }, name)
 	}, [])
 
 	useLayoutEffect(() => {

--- a/packages/shader-composer-toybox/src/noise/GerstnerWave.ts
+++ b/packages/shader-composer-toybox/src/noise/GerstnerWave.ts
@@ -25,7 +25,7 @@ export const GerstnerWave = (
 	direction: Value<"vec2"> = new Vector2(1, 0),
 	steepness: Value<"float"> = 1,
 	wavelength: Value<"float"> = 1,
-	offset: Value<"float"> = Time()
+	offset: Value<"float"> = 0
 ) =>
 	Vec3($`${gerstnerWave}(${p}, ${direction}, ${steepness}, ${wavelength}, ${offset})`, {
 		name: "Gerstner Wave"

--- a/packages/shader-composer-toybox/src/noise/GerstnerWave.ts
+++ b/packages/shader-composer-toybox/src/noise/GerstnerWave.ts
@@ -25,7 +25,7 @@ export const GerstnerWave = (
 	direction: Value<"vec2"> = new Vector2(1, 0),
 	steepness: Value<"float"> = 1,
 	wavelength: Value<"float"> = 1,
-	offset: Value<"float"> = Time
+	offset: Value<"float"> = Time()
 ) =>
 	Vec3($`${gerstnerWave}(${p}, ${direction}, ${steepness}, ${wavelength}, ${offset})`, {
 		name: "Gerstner Wave"

--- a/packages/shader-composer/src/__snapshots__/compiler.test.ts.snap
+++ b/packages/shader-composer/src/__snapshots__/compiler.test.ts.snap
@@ -235,13 +235,13 @@ exports[`compileShader when rendering units with registered uniforms adds unifor
 precision highp float;
 
 /*** UNIT: Anonymous ***/
-uniform float u_foo;
+uniform float u_Anonymous_1;
 
 
 void main()
 {
   /*** UNIT: Anonymous ***/
-  float Anonymous_1 = u_time;
+  float Anonymous_1 = u_Anonymous_1;
   
   
 }"
@@ -253,13 +253,13 @@ exports[`compileShader when rendering units with registered uniforms adds unifor
 precision highp float;
 
 /*** UNIT: Anonymous ***/
-uniform float u_foo;
+uniform float u_Anonymous_1;
 
 
 void main()
 {
   /*** UNIT: Anonymous ***/
-  float Anonymous_1 = u_time;
+  float Anonymous_1 = u_Anonymous_1;
   
   
 }"

--- a/packages/shader-composer/src/__snapshots__/compiler.test.ts.snap
+++ b/packages/shader-composer/src/__snapshots__/compiler.test.ts.snap
@@ -264,3 +264,35 @@ void main()
   
 }"
 `;
+
+exports[`compileShader when rendering units without variables doesn't declare global or local value variables 1`] = `
+"/*** PROGRAM: VERTEX ***/
+
+precision highp float;
+
+void main()
+{
+  /*** UNIT: Anonymous ***/
+  {
+    /* Hi from the vertex program */
+  }
+  
+  
+}"
+`;
+
+exports[`compileShader when rendering units without variables doesn't declare global or local value variables 2`] = `
+"/*** PROGRAM: FRAGMENT ***/
+
+precision highp float;
+
+void main()
+{
+  /*** UNIT: Anonymous ***/
+  {
+    /* Hi from the vertex program */
+  }
+  
+  
+}"
+`;

--- a/packages/shader-composer/src/compiler.test.ts
+++ b/packages/shader-composer/src/compiler.test.ts
@@ -102,10 +102,8 @@ describe("compileShader", () => {
 
 	describe("when rendering units with registered uniforms", () => {
 		const getShader = () => {
-			const unitWithUniform = Float($`u_time`, {
-				uniforms: {
-					u_foo: { type: "float", value: 0 }
-				}
+			const unitWithUniform = Float(0, {
+				uniform: { value: 0 }
 			})
 
 			const [shader] = compileShader(unitWithUniform)
@@ -121,11 +119,7 @@ describe("compileShader", () => {
 		it("adds the uniform value object to the returned uniforms object", () => {
 			expect(getShader().uniforms).toMatchInlineSnapshot(`
 			Object {
-			  "u_foo": Object {
-			    "type": "float",
-			    "value": 0,
-			  },
-			  "u_time": Object {
+			  "u_Anonymous_1": Object {
 			    "value": 0,
 			  },
 			}

--- a/packages/shader-composer/src/compiler.test.ts
+++ b/packages/shader-composer/src/compiler.test.ts
@@ -85,6 +85,21 @@ describe("compileShader", () => {
 		expect(shader.fragmentShader).toMatchSnapshot()
 	})
 
+	describe("when rendering units without variables", () => {
+		it("doesn't declare global or local value variables", () => {
+			const unitWithoutVariable = Float(1, {
+				variable: false,
+				vertex: { body: $`/* Hi from the vertex program */` },
+				fragment: { body: $`/* Hi from the vertex program */` }
+			})
+
+			const [shader] = compileShader(unitWithoutVariable)
+
+			expect(shader.vertexShader).toMatchSnapshot()
+			expect(shader.fragmentShader).toMatchSnapshot()
+		})
+	})
+
 	describe("when rendering units with registered uniforms", () => {
 		const getShader = () => {
 			const unitWithUniform = Float($`u_time`, {

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -3,7 +3,7 @@ import { Expression, isExpression } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import { isSnippet, Snippet } from "./snippets"
 import { uniformName } from "./stdlib"
-import { isUnit, Program, UniformConfiguration, Unit, UpdateCallback } from "./units"
+import { isUnit, Program, Unit, UpdateCallback } from "./units"
 import {
 	assignment,
 	block,

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -242,7 +242,6 @@ export const compileShader = (root: Unit) => {
 	STEP 6: Build per-frame update function.
 	*/
 	const update = (dt: number) => {
-		// uniforms.u_time.value += dt
 		updates.forEach((u) => u(dt))
 	}
 

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -1,5 +1,4 @@
 import { Vector2 } from "three"
-import { $ } from "../expressions"
 import { Float, GLSLType, JSTypes, Unit, UnitConfig } from "../units"
 
 export const uniformName = (unit: Unit) => `u_${unit._unitConfig.variableName}`
@@ -17,8 +16,7 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	const uniform = { value: initialValue }
 
 	/* Create the actual unit that represents the uniform. */
-
-	const unit = Unit<T>(type, $`/* placeholder */`, {
+	const unit = Unit<T>(type, undefined, {
 		name: `Uniform (${type})`,
 		...extras,
 		uniform,

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -2,25 +2,26 @@ import { Vector2 } from "three"
 import { $ } from "../expressions"
 import { Float, GLSLType, JSTypes, Unit, UnitConfig } from "../units"
 
+export const uniformName = (unit: Unit) => `u_${unit._unitConfig.variableName}`
+
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	type: T,
 	value: U,
-	name: string = uniqueUniformName(),
 	extras?: Partial<UnitConfig<T>>
 ) => {
-	const uniform = { type, value }
+	const uniform = { value }
 
-	const unit = Unit<T>(type, $`${name}`, {
+	const unit = Unit<T>(type, $`/* BREAK */`, {
+		name: `Uniform (${type})`,
 		...extras,
-		name: `Uniform: ${name}`,
-		uniforms: { [name]: uniform },
+		uniform,
 		variable: false
 	})
 
 	return {
 		...unit,
 
-		toString: () => name,
+		toString: () => `u_${unit._unitConfig.variableName}`,
 
 		set value(v: U) {
 			uniform.value = v
@@ -33,11 +34,12 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 }
 
 export const Time = () => {
-	const uniform = Uniform("float", 0)
+	const uniform = Uniform("float", 0, { name: "Time Uniform" })
 
-	return Float(uniform, { update: (dt) => (uniform.value += dt) })
+	return Float(uniform, {
+		name: "Time",
+		update: (dt) => (uniform.value += dt)
+	})
 }
 
-export const Resolution = Uniform("vec2", new Vector2(0, 0), "u_resolution")
-
-export const uniqueUniformName = () => `u_${Math.floor(Math.random() * 1000000)}`
+export const Resolution = Uniform("vec2", new Vector2(0, 0))

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -1,18 +1,11 @@
 import { Vector2 } from "three"
 import { $ } from "../expressions"
-import {
-	Float,
-	GLSLType,
-	JSTypes,
-	UniformConfiguration,
-	Unit,
-	UnitConfig
-} from "../units"
+import { Float, GLSLType, JSTypes, Unit, UnitConfig } from "../units"
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	type: T,
 	value: U,
-	name: string,
+	name: string = uniqueUniformName(),
 	extras?: Partial<UnitConfig<T>>
 ) => {
 	const uniform = { type, value }
@@ -40,7 +33,7 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 }
 
 export const Time = () => {
-	const uniform = Uniform("float", 0, uniqueUniformName())
+	const uniform = Uniform("float", 0)
 
 	return Float(uniform, { update: (dt) => (uniform.value += dt) })
 }

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -11,11 +11,14 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 
 	const unit = Unit<T>(type, $`${name}`, {
 		name: `Uniform: ${name}`,
-		uniforms: { [name]: uniform }
+		uniforms: { [name]: uniform },
+		variable: false
 	})
 
 	return {
 		...unit,
+
+		toString: () => name,
 
 		set value(v: U) {
 			uniform.value = v

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -1,13 +1,23 @@
 import { Vector2 } from "three"
 import { $ } from "../expressions"
-import { GLSLType, JSTypes, UniformConfiguration, Unit, UnitConfig } from "../units"
+import {
+	Float,
+	GLSLType,
+	JSTypes,
+	UniformConfiguration,
+	Unit,
+	UnitConfig
+} from "../units"
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
-	uniform: UniformConfiguration<T, U>,
+	type: T,
+	value: U,
 	name: string,
 	extras?: Partial<UnitConfig<T>>
 ) => {
-	const unit = Unit<T>(uniform.type, $`${name}`, {
+	const uniform = { type, value }
+
+	const unit = Unit<T>(type, $`${name}`, {
 		...extras,
 		name: `Uniform: ${name}`,
 		uniforms: { [name]: uniform },
@@ -30,16 +40,11 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 }
 
 export const Time = () => {
-	const time: UniformConfiguration<"float", number> = { type: "float", value: 0 }
+	const uniform = Uniform("float", 0, uniqueUniformName())
 
-	return Uniform(time, uniqueUniformName(), {
-		update: (dt) => (time.value += dt)
-	})
+	return Float(uniform, { update: (dt) => (uniform.value += dt) })
 }
 
-export const Resolution = Uniform(
-	{ type: "vec2", value: new Vector2(0, 0) },
-	"u_resolution"
-)
+export const Resolution = Uniform("vec2", new Vector2(0, 0), "u_resolution")
 
 export const uniqueUniformName = () => `u_${Math.floor(Math.random() * 1000000)}`

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -1,15 +1,17 @@
 import { Vector2 } from "three"
 import { $ } from "../expressions"
-import { GLSLType, JSTypes, UniformConfiguration, Unit } from "../units"
+import { GLSLType, JSTypes, UniformConfiguration, Unit, UnitConfig } from "../units"
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	type: T,
 	name: string,
-	value: U
+	value: U,
+	extras?: Partial<UnitConfig<T>>
 ) => {
 	const uniform: UniformConfiguration<T, U> = { type, value }
 
 	const unit = Unit<T>(type, $`${name}`, {
+		...extras,
 		name: `Uniform: ${name}`,
 		uniforms: { [name]: uniform },
 		variable: false
@@ -30,6 +32,8 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	}
 }
 
-export const Time = Uniform("float", "u_time", 0)
+export const Time = Uniform("float", "u_time", 0, {
+	update: (dt) => console.log(dt)
+})
 
 export const Resolution = Uniform("vec2", "u_resolution", new Vector2(0, 0))

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -6,10 +6,17 @@ export const uniformName = (unit: Unit) => `u_${unit._unitConfig.variableName}`
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	type: T,
-	value: U,
+	initialValue: U,
 	extras?: Partial<UnitConfig<T>>
 ) => {
-	const uniform = { value }
+	/*
+	Create a uniform object. One of the reasons we need to wrap the value here
+	is that there is a good chance that we will need to mutate it, and we can only
+	reliably do this for scalar values if they are wrapped.
+	*/
+	const uniform = { value: initialValue }
+
+	/* Create the actual unit that represents the uniform. */
 
 	const unit = Unit<T>(type, $`/* BREAK */`, {
 		name: `Uniform (${type})`,
@@ -18,11 +25,13 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 		variable: false
 	})
 
+	/* Return the unit with some API bits mixed in. */
 	return {
 		...unit,
 
 		toString: () => `u_${unit._unitConfig.variableName}`,
 
+		/** The uniform's value. */
 		set value(v: U) {
 			uniform.value = v
 		},

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -18,7 +18,7 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 
 	/* Create the actual unit that represents the uniform. */
 
-	const unit = Unit<T>(type, $`/* BREAK */`, {
+	const unit = Unit<T>(type, $`/* placeholder */`, {
 		name: `Uniform (${type})`,
 		...extras,
 		uniform,

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -3,14 +3,11 @@ import { $ } from "../expressions"
 import { GLSLType, JSTypes, UniformConfiguration, Unit, UnitConfig } from "../units"
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
-	type: T,
+	uniform: UniformConfiguration<T, U>,
 	name: string,
-	value: U,
 	extras?: Partial<UnitConfig<T>>
 ) => {
-	const uniform: UniformConfiguration<T, U> = { type, value }
-
-	const unit = Unit<T>(type, $`${name}`, {
+	const unit = Unit<T>(uniform.type, $`${name}`, {
 		...extras,
 		name: `Uniform: ${name}`,
 		uniforms: { [name]: uniform },
@@ -32,8 +29,17 @@ export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	}
 }
 
-export const Time = Uniform("float", "u_time", 0, {
-	update: (dt) => console.log(dt)
-})
+export const Time = () => {
+	const time: UniformConfiguration<"float", number> = { type: "float", value: 0 }
 
-export const Resolution = Uniform("vec2", "u_resolution", new Vector2(0, 0))
+	return Uniform(time, uniqueUniformName(), {
+		update: (dt) => (time.value += dt)
+	})
+}
+
+export const Resolution = Uniform(
+	{ type: "vec2", value: new Vector2(0, 0) },
+	"u_resolution"
+)
+
+export const uniqueUniformName = () => `u_${Math.floor(Math.random() * 1000000)}`

--- a/packages/shader-composer/src/stdlib/textures.ts
+++ b/packages/shader-composer/src/stdlib/textures.ts
@@ -1,12 +1,11 @@
+import { Texture } from "three"
 import { $ } from "../expressions"
 import { Bool, Float, Value, Vec3, Vec4 } from "../units"
 
-/* TODO: find a better way to create the uniform here. Maybe reference an actual Uniform node and make it not write itself into a variable? */
-export const Sampler2D = (name: string) => ({
+export const Sampler2D = (name: string, texture?: Texture) => ({
 	...Bool(true, {
 		name: `Sampler2D: ${name}`,
-		vertex: { header: $`uniform sampler2D ${name};` },
-		fragment: { header: $`uniform sampler2D ${name};` }
+		uniforms: { [name]: { type: "sampler2D", value: texture } }
 	}),
 
 	toString: () => name

--- a/packages/shader-composer/src/stdlib/textures.ts
+++ b/packages/shader-composer/src/stdlib/textures.ts
@@ -1,6 +1,6 @@
 import { Texture } from "three"
 import { $ } from "../expressions"
-import { Bool, Float, Value, Vec3, Vec4 } from "../units"
+import { Bool, Float, Unit, Value, Vec3, Vec4 } from "../units"
 
 export const Sampler2D = (name: string, texture?: Texture) => ({
 	...Bool(true, {
@@ -13,7 +13,7 @@ export const Sampler2D = (name: string, texture?: Texture) => ({
 
 export type Sampler2D = ReturnType<typeof Sampler2D>
 
-export const Texture2D = (sampler2D: Sampler2D, xy: Value<"vec2">) => {
+export const Texture2D = (sampler2D: Unit<"sampler2D">, xy: Value<"vec2">) => {
 	const unit = Vec4($`texture2D(${sampler2D}, ${xy})`, {
 		name: "Texture2D"
 	})

--- a/packages/shader-composer/src/stdlib/textures.ts
+++ b/packages/shader-composer/src/stdlib/textures.ts
@@ -1,17 +1,5 @@
-import { Texture } from "three"
 import { $ } from "../expressions"
-import { Bool, Float, Unit, Value, Vec3, Vec4 } from "../units"
-
-export const Sampler2D = (name: string, texture?: Texture) => ({
-	...Bool(true, {
-		name: `Sampler2D: ${name}`,
-		uniforms: { [name]: { type: "sampler2D", value: texture } }
-	}),
-
-	toString: () => name
-})
-
-export type Sampler2D = ReturnType<typeof Sampler2D>
+import { Float, Unit, Value, Vec3, Vec4 } from "../units"
 
 export const Texture2D = (sampler2D: Unit<"sampler2D">, xy: Value<"vec2">) => {
 	const unit = Vec4($`texture2D(${sampler2D}, ${xy})`, {

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -48,6 +48,8 @@ export type UniformConfiguration<T extends GLSLType, U extends JSTypes[T]> = {
 	value: U
 }
 
+export type UpdateCallback = (dt: number) => void
+
 export type UnitConfig<T extends GLSLType> = {
 	/**
 	 * Human-readable name of this unit.
@@ -103,6 +105,11 @@ export type UnitConfig<T extends GLSLType> = {
 	 * object returned by `compilerShader`.
 	 */
 	uniforms?: Record<string, UniformConfiguration<any, any>>
+
+	/**
+	 * A callback that will be executed once per frame.
+	 */
+	update?: UpdateCallback
 
 	/* Chunks */
 	vertex?: {

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -52,11 +52,6 @@ export type GLSLTypeFor<T extends any> = T extends boolean
 
 export type Value<T extends GLSLType = any> = Expression | JSTypes[T] | Unit<T>
 
-export type UniformConfiguration<T extends GLSLType, U extends JSTypes[T]> = {
-	type: T
-	value: U
-}
-
 export type UpdateCallback = (dt: number) => void
 
 export type UnitConfig<T extends GLSLType> = {

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -49,16 +49,59 @@ export type UniformConfiguration<T extends GLSLType, U extends JSTypes[T]> = {
 }
 
 export type UnitConfig<T extends GLSLType> = {
+	/**
+	 * Human-readable name of this unit.
+	 */
 	name: string
+
+	/**
+	 * Machine-readable name of the global variable for this unit.
+	 * Will be recreated by the compiler, so no need to set this yourself.
+	 */
 	variableName: string
 
+	/**
+	 * The GLSL type of this unit.
+	 */
 	type: T
+
+	/**
+	 * The value of this unit. Can be a reference to another unit,
+	 * a JavaScript type that matches this unit's GLSL type, or
+	 * an Expression.
+	 */
 	value: Value<T>
 
+	/**
+	 * If this is set to "vertex" or "fragment", the compiler will
+	 * only ever render this node in the specified program. If you
+	 * have units referencing gl_* variables that only exist in one
+	 * of the programs, use this to make sure they never appear
+	 * in the other program (which would lead to compilation failure.)
+	 */
 	only?: Program
+
+	/**
+	 * When set to true, the value of this unit will be represented
+	 * as a "global" variable (within the program's `main` function.)
+	 * Defaults to true, since most units will want to use this.
+	 * When you set this to false, you need to override the unit's
+	 * `toString` function to allow other units to reference it.
+	 */
 	variable: boolean
+
+	/**
+	 * When set to true, this variable will automatically declare a varying,
+	 * calculate/source its value in the vertex program only, and pass the
+	 * result to the fragment program through that varying. Default: false.
+	 */
 	varying: boolean
 
+	/**
+	 * An object of uniforms. Uniforms added here will automatically be
+	 * declared in the program headers, and also made available in the
+	 * object returned by `compilerShader`.
+	 */
 	uniforms?: Record<string, UniformConfiguration<any, any>>
 
 	/* Chunks */

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -1,13 +1,4 @@
-import {
-	Color,
-	IUniform,
-	Matrix3,
-	Matrix4,
-	Texture,
-	Vector2,
-	Vector3,
-	Vector4
-} from "three"
+import { Color, Matrix3, Matrix4, Texture, Vector2, Vector3, Vector4 } from "three"
 import { $, Expression } from "./expressions"
 import { identifier } from "./util/concatenator3000"
 

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
+import { Color, Matrix3, Matrix4, Texture, Vector2, Vector3, Vector4 } from "three"
 import { $, Expression } from "./expressions"
 import { identifier } from "./util/concatenator3000"
 
@@ -13,6 +13,7 @@ export type GLSLType =
 	| "vec4"
 	| "mat3"
 	| "mat4"
+	| "sampler2D"
 
 export type JSTypes = {
 	bool: boolean
@@ -23,6 +24,7 @@ export type JSTypes = {
 	vec4: Vector4
 	mat3: Matrix3
 	mat4: Matrix4
+	sampler2D: Texture
 }
 
 export type GLSLTypeFor<T extends any> = T extends boolean
@@ -54,6 +56,7 @@ export type UnitConfig<T extends GLSLType> = {
 	value: Value<T>
 
 	only?: Program
+	variable: boolean
 	varying: boolean
 
 	uniforms?: Record<string, UniformConfiguration<any, any>>
@@ -85,6 +88,7 @@ export const Unit = <T extends GLSLType>(
 		name: "Anonymous",
 		type,
 		value,
+		variable: true,
 		varying: false,
 		variableName: identifier("var", Math.floor(Math.random() * 1000000)),
 		..._config

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -25,6 +25,20 @@ export type JSTypes = {
 	mat4: Matrix4
 }
 
+export type GLSLTypeFor<T extends any> = T extends boolean
+	? "bool"
+	: T extends number
+	? "float"
+	: T extends Vector2
+	? "vec2"
+	: T extends Vector3 | Color
+	? "vec3"
+	: T extends Matrix3
+	? "mat3"
+	: T extends Matrix4
+	? "mat4"
+	: never
+
 export type Value<T extends GLSLType = any> = Expression | JSTypes[T] | Unit<T>
 
 export type UniformConfiguration<T extends GLSLType, U extends JSTypes[T]> = {

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -27,20 +27,6 @@ export type JSTypes = {
 	sampler2D: Texture
 }
 
-export type GLSLTypeFor<T extends any> = T extends boolean
-	? "bool"
-	: T extends number
-	? "float"
-	: T extends Vector2
-	? "vec2"
-	: T extends Vector3 | Color
-	? "vec3"
-	: T extends Matrix3
-	? "mat3"
-	: T extends Matrix4
-	? "mat4"
-	: never
-
 export type Value<T extends GLSLType = any> = Expression | JSTypes[T] | Unit<T>
 
 export type UpdateCallback = (dt: number) => void

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -81,7 +81,7 @@ export type UnitConfig<T extends GLSLType> = {
 	 * a JavaScript type that matches this unit's GLSL type, or
 	 * an Expression.
 	 */
-	value: Value<T>
+	value: Value<T> | undefined
 
 	/**
 	 * If this is set to "vertex" or "fragment", the compiler will
@@ -140,7 +140,7 @@ export type Unit<T extends GLSLType = any, A extends {} = {}> = {
 
 export const Unit = <T extends GLSLType>(
 	type: T,
-	value: Value<T>,
+	value: Value<T> | undefined,
 	_config?: Partial<UnitConfig<T>>
 ): Unit<T> => {
 	const config: UnitConfig<T> = {

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -1,4 +1,13 @@
-import { Color, Matrix3, Matrix4, Texture, Vector2, Vector3, Vector4 } from "three"
+import {
+	Color,
+	IUniform,
+	Matrix3,
+	Matrix4,
+	Texture,
+	Vector2,
+	Vector3,
+	Vector4
+} from "three"
 import { $, Expression } from "./expressions"
 import { identifier } from "./util/concatenator3000"
 
@@ -104,7 +113,7 @@ export type UnitConfig<T extends GLSLType> = {
 	 * declared in the program headers, and also made available in the
 	 * object returned by `compilerShader`.
 	 */
-	uniforms?: Record<string, UniformConfiguration<any, any>>
+	uniform?: { value: JSTypes[T] }
 
 	/**
 	 * A callback that will be executed once per frame.


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/use-uniform?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=use-uniform">VS Code</a>

<!-- open-in-codesandbox:complete -->


- [x] Add `useUniform` to sc-r3f
- [x] ~Figure out a way to let both `Uniform` and `useUniform` infer their type from the value passed in to them~ Maybe later.
- [ ] Figure out a way to reactively update color (vector) uniforms without creating new objects all the time
- [x] Make passing in a uniform name optional
- [x] Allow units to declare per-frame updates
- [x] #26 
- [x] Cleanup: refactor `uniforms` to only allow a single uniform
- [x] Cleanup: allow undefined values for nodes