### PR TITLE
Return used units

### DIFF
--- a/.changeset/selfish-feet-hug.md
+++ b/.changeset/selfish-feet-hug.md
@@ -1,0 +1,6 @@
+---
+"shader-composer": minor
+"shader-composer-r3f": minor
+---
+
+**Breaking Change:** The return signature of `compileShader` has been changed. It now returns `[shader, meta]`, where `shader` is the object containing the shader properties (like before), and `meta` is an object containing the `update` function, and a `units` array containing all units used in the tree.

--- a/packages/shader-composer-r3f/src/hooks.ts
+++ b/packages/shader-composer-r3f/src/hooks.ts
@@ -3,7 +3,7 @@ import { useLayoutEffect, useMemo } from "react"
 import { compileShader, GLSLType, JSTypes, Uniform, Unit } from "shader-composer"
 
 export const useShader = (ctor: () => Unit, deps?: any) => {
-	const [shader, update] = useMemo(() => compileShader(ctor()), deps)
+	const [shader, { update }] = useMemo(() => compileShader(ctor()), deps)
 	useFrame((_, dt) => update(dt))
 	return shader
 }

--- a/packages/shader-composer/src/compiler.test.ts
+++ b/packages/shader-composer/src/compiler.test.ts
@@ -130,7 +130,7 @@ describe("compileShader", () => {
 	it("returns a list of all units contained in the tree", () => {
 		const a = Float(1)
 		const root = Float(a)
-		const [shader, _, units] = compileShader(root)
+		const [shader, { units }] = compileShader(root)
 
 		expect(units).toEqual([root, a])
 	})

--- a/packages/shader-composer/src/compiler.test.ts
+++ b/packages/shader-composer/src/compiler.test.ts
@@ -126,4 +126,12 @@ describe("compileShader", () => {
 		`)
 		})
 	})
+
+	it("returns a list of all units contained in the tree", () => {
+		const a = Float(1)
+		const root = Float(a)
+		const [shader, _, units] = compileShader(root)
+
+		expect(units).toEqual([root, a])
+	})
 })

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -260,15 +260,18 @@ export const compileShader = (root: Unit) => {
 	/*
 	DONE! Let's return everything and go on a lengthy vacation somewhere nice.
 	*/
-	return [
-		{
-			vertexShader,
-			fragmentShader,
-			uniforms
-		},
+	const shader = {
+		vertexShader,
+		fragmentShader,
+		uniforms
+	}
+
+	const meta = {
 		update,
 		units
-	] as const
+	}
+
+	return [shader, meta] as const
 }
 
 type CompilerState = ReturnType<typeof CompilerState>

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -243,6 +243,14 @@ export const compileShader = (root: Unit) => {
 	])
 
 	/*
+	Build a complete list of all units included in the tree. The code consuming
+	this function might have a need for it!
+	*/
+	const units = [
+		...new Set<Unit>([...fragmentState.seen, ...vertexState.seen].filter(isUnit))
+	]
+
+	/*
 	STEP 6: Build per-frame update function.
 	*/
 	const update = (dt: number) => {
@@ -258,7 +266,8 @@ export const compileShader = (root: Unit) => {
 			fragmentShader,
 			uniforms
 		},
-		update
+		update,
+		units
 	] as const
 }
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/return-units?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=return-units">VS Code</a>

<!-- open-in-codesandbox:complete -->


This changes the return signature of `compileShader` to return `update` and `units` as an object.