### PR TITLE
Allow explicit naming of uniforms

### DIFF
--- a/.changeset/thick-games-begin.md
+++ b/.changeset/thick-games-begin.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": patch
+---
+
+**Added:** Units with uniforms now have a new configuration property `uniformName` which can be set by the user to explicitly configure the name of the shader uniform. If the name is omitted, a unique name will be generated automatically (as before).

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -2,6 +2,7 @@ import { IUniform } from "three"
 import { Expression, isExpression } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import { isSnippet, Snippet } from "./snippets"
+import { uniformName } from "./stdlib"
 import { isUnit, Program, Unit, UpdateCallback } from "./units"
 import {
 	assignment,
@@ -85,12 +86,12 @@ const compileUnit = (unit: Unit, program: Program, state: CompilerState) => {
 	}
 
 	/* Declare uniform, if one is configured. */
-	if (unit._unitConfig.uniform && unit._unitConfig.uniformName) {
+	if (unit._unitConfig.uniform) {
 		/* Register uniform with compiler state */
-		state.uniforms.set(unit._unitConfig.uniformName, unit._unitConfig.uniform)
+		state.uniforms.set(uniformName(unit), unit._unitConfig.uniform)
 
 		/* Declare uniforms in header */
-		header.push(statement("uniform", unit._unitConfig.type, unit._unitConfig.uniformName))
+		header.push(statement("uniform", unit._unitConfig.type, uniformName(unit)))
 	}
 
 	/* Add header if present */
@@ -105,8 +106,8 @@ const compileUnit = (unit: Unit, program: Program, state: CompilerState) => {
 	const value =
 		unit._unitConfig.varying && program === "fragment"
 			? `v_${unit._unitConfig.variableName}`
-			: unit._unitConfig.uniform && unit._unitConfig.uniformName
-			? unit._unitConfig.uniformName
+			: unit._unitConfig.uniform
+			? uniformName(unit)
 			: glslRepresentation(unit._unitConfig.value, unit._unitConfig.type)
 
 	state.body.push(beginUnit(unit))
@@ -181,11 +182,6 @@ const prepareItem = (item: Unit | Expression, state = CompilerState()) => {
 			sluggify(item._unitConfig.name),
 			state.nextid()
 		)
-
-		/* If a uniform is given, but no uniform name, make one up! */
-		if (item._unitConfig.uniform && !item._unitConfig.uniformName) {
-			item._unitConfig.uniformName = `u_${item._unitConfig.variableName}`
-		}
 	}
 }
 

--- a/packages/shader-composer/src/stdlib/input.test.ts
+++ b/packages/shader-composer/src/stdlib/input.test.ts
@@ -1,0 +1,19 @@
+import { glslRepresentation } from "../glslRepresentation"
+import { Uniform } from "./input"
+
+describe("Uniform", () => {
+	it("uses its uniform name as its string representation", () => {
+		const uniform = Uniform("float", 0, { variableName: "foo" })
+		expect(glslRepresentation(uniform)).toBe("u_foo")
+	})
+
+	it("uses u_variableName as the default name if none other is given", () => {
+		const uniform = Uniform("float", 0, { variableName: "foo123" })
+		expect(glslRepresentation(uniform)).toBe("u_foo123")
+	})
+
+	it("allows the user to set a uniform name explicitly", () => {
+		const uniform = Uniform("float", 0, { variableName: "foo", uniformName: "u_bar" })
+		expect(glslRepresentation(uniform)).toBe("u_bar")
+	})
+})

--- a/packages/shader-composer/src/stdlib/input.ts
+++ b/packages/shader-composer/src/stdlib/input.ts
@@ -2,7 +2,8 @@ import { Vector2 } from "three"
 import { GLSLType, JSTypes, Unit, UnitConfig } from "../units"
 import { Float } from "./values"
 
-export const uniformName = (unit: Unit) => `u_${unit._unitConfig.variableName}`
+export const uniformName = (unit: Unit) =>
+	unit._unitConfig.uniformName ?? `u_${unit._unitConfig.variableName}`
 
 export const Uniform = <T extends GLSLType, U extends JSTypes[T]>(
 	type: T,

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -89,11 +89,12 @@ export type UnitConfig<T extends GLSLType> = {
 	varying: boolean
 
 	/**
-	 * An object of uniforms. Uniforms added here will automatically be
+	 * An optional uniform object. It will automatically be
 	 * declared in the program headers, and also made available in the
 	 * object returned by `compilerShader`.
 	 */
 	uniform?: { value: JSTypes[T] }
+	uniformName?: string
 
 	/**
 	 * A callback that will be executed once per frame.


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/explicit-uniform-naming?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=explicit-uniform-naming">VS Code</a>

<!-- open-in-codesandbox:complete -->


