### PR TITLE
Add a simple math API to units

### DIFF
--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -147,10 +147,25 @@ export const Unit = <T extends GLSLType>(
     toString: () => config.variableName,
     _unitConfig: config,
 
-    add: (other: Input) => Unit(type, $`(${unit} + ${other})`),
-    sub: (other: Input) => Unit(type, $`(${unit} - ${other})`),
-    mul: (other: Input) => Unit(type, $`(${unit} * ${other})`),
-    div: (other: Input) => Unit(type, $`(${unit} / ${other})`)
+    add: (other: Input) =>
+      Unit(type, $`(${unit} + ${other})`, {
+        name: `Add (${type})`
+      }),
+
+    sub: (other: Input) =>
+      Unit(type, $`(${unit} - ${other})`, {
+        name: `Subtract (${type})`
+      }),
+
+    mul: (other: Input) =>
+      Unit(type, $`(${unit} * ${other})`, {
+        name: `Multiply (${type})`
+      }),
+
+    div: (other: Input) =>
+      Unit(type, $`(${unit} / ${other})`, {
+        name: `Divide (${type})`
+      })
   }
 
   return unit

--- a/packages/shader-composer/src/units.ts
+++ b/packages/shader-composer/src/units.ts
@@ -1,5 +1,5 @@
 import { Color, Matrix3, Matrix4, Texture, Vector2, Vector3, Vector4 } from "three"
-import { Expression } from "./expressions"
+import { $, Expression } from "./expressions"
 import { identifier } from "./util/concatenator3000"
 
 export type Program = "vertex" | "fragment"
@@ -120,6 +120,11 @@ export type Unit<T extends GLSLType = any> = {
   _: "Unit"
   _unitConfig: UnitConfig<T>
   toString: () => string
+
+  add: (other: Input) => Unit<T>
+  sub: (other: Input) => Unit<T>
+  mul: (other: Input) => Unit<T>
+  div: (other: Input) => Unit<T>
 }
 
 export const Unit = <T extends GLSLType>(
@@ -140,7 +145,12 @@ export const Unit = <T extends GLSLType>(
   const unit: Unit<T> = {
     _: "Unit",
     toString: () => config.variableName,
-    _unitConfig: config
+    _unitConfig: config,
+
+    add: (other: Input) => Unit(type, $`(${unit} + ${other})`),
+    sub: (other: Input) => Unit(type, $`(${unit} - ${other})`),
+    mul: (other: Input) => Unit(type, $`(${unit} * ${other})`),
+    div: (other: Input) => Unit(type, $`(${unit} / ${other})`)
   }
 
   return unit


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/simple-math-api?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=simple-math-api">VS Code</a>

<!-- open-in-codesandbox:complete -->


