### PR TITLE
Don't leak matrices into fragment shader

### DIFF
--- a/.changeset/green-bees-drum.md
+++ b/.changeset/green-bees-drum.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": minor
+---
+
+Added `UsingInstancing`, a boolean unit that is true when instanced rendering is being used.

--- a/.changeset/tidy-toys-explode.md
+++ b/.changeset/tidy-toys-explode.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": minor
+---
+
+**Breaking Change:** `InstanceMatrix`, which wraps the attribute-provided `instanceMatrix`, has been marked as "vertex only" to prevent it from accidentally leaking into the fragment shader through a varying. It is recommended that if you are using this attribute, you should wrap it or the derived value into a unit with `varying: true`.

--- a/apps/examples/src/examples/ForceField.tsx
+++ b/apps/examples/src/examples/ForceField.tsx
@@ -77,6 +77,8 @@ export default function ForceField() {
     })
   }, [])
 
+  console.log(shader.fragmentShader)
+
   return (
     <group>
       <Float floatIntensity={1} speed={2}>

--- a/apps/examples/src/examples/ForceField.tsx
+++ b/apps/examples/src/examples/ForceField.tsx
@@ -57,8 +57,7 @@ export default function ForceField() {
     const sceneDepth = PerspectiveDepth(ScreenUV, sceneDepthTexture)
 
     const distance = pipe(
-      VertexPosition,
-      (v) => LocalToViewSpace(v).z,
+      VertexPosition.view.z,
       (v) => Add(v, 0.4),
       (v) => Sub(v, sceneDepth),
       (v) => Smoothstep(0, 1, v)

--- a/apps/examples/src/examples/ForceField.tsx
+++ b/apps/examples/src/examples/ForceField.tsx
@@ -77,8 +77,6 @@ export default function ForceField() {
     })
   }, [])
 
-  console.log(shader.fragmentShader)
-
   return (
     <group>
       <Float floatIntensity={1} speed={2}>

--- a/packages/shader-composer/src/compiler.test.ts
+++ b/packages/shader-composer/src/compiler.test.ts
@@ -153,7 +153,7 @@ describe("compileShader", () => {
     const a = Float(1, { name: "A", only: "vertex" })
     const root = Master({ fragment: { body: $`${a}` } })
     expect(() => compileShader(root)).toThrowErrorMatchingInlineSnapshot(
-      `"Encountered a unit \\"A\\" that is not allowed in the \\"fragment\\" program."`
+      `"Encountered a unit \\"A\\" that is only allowed in the vertex shader, but was encountered when compiling the fragment shader. Consider wrapping the value, or the derived value you're interested in, in a Unit that has a varying."`
     )
   })
 })

--- a/packages/shader-composer/src/compiler.ts
+++ b/packages/shader-composer/src/compiler.ts
@@ -42,7 +42,9 @@ const compileUnit = (unit: Unit, program: Program, state: CompilerState) => {
 	the requested program. */
   if (!isUnitInProgram(unit, program)) {
     throw new Error(
-      `Encountered a unit "${unit._unitConfig.name}" that is not allowed in the "${program}" program.`
+      program === "vertex"
+        ? `Encountered a unit "${unit._unitConfig.name}" that is only allowed in the fragment shader, but was encountered when compiling the vertex shader. Please check your unit connections.`
+        : `Encountered a unit "${unit._unitConfig.name}" that is only allowed in the vertex shader, but was encountered when compiling the fragment shader. Consider wrapping the value, or the derived value you're interested in, in a Unit that has a varying.`
     )
   }
 

--- a/packages/shader-composer/src/stdlib/geometry.ts
+++ b/packages/shader-composer/src/stdlib/geometry.ts
@@ -6,17 +6,17 @@ import { Bool, Mat4, Vec2, Vec3 } from "./values"
 
 export const ViewMatrix = Mat4($`viewMatrix`, {
   name: "View Matrix",
-  varying: true
+  only: "vertex"
 })
 
 export const ModelMatrix = Mat4($`modelMatrix`, {
   name: "Model Matrix",
-  varying: true
+  only: "vertex"
 })
 
 export const ModelViewMatrix = Mat4($`modelViewMatrix`, {
   name: "ModelView Matrix",
-  varying: true
+  only: "vertex"
 })
 
 export const UsingInstancing = Bool($`
@@ -37,7 +37,7 @@ export const InstanceMatrix = Mat4(
 `,
   {
     name: "Instance Matrix",
-    varying: true
+    only: "vertex"
   }
 )
 

--- a/packages/shader-composer/src/stdlib/geometry.ts
+++ b/packages/shader-composer/src/stdlib/geometry.ts
@@ -4,19 +4,28 @@ import { GLSLType, Input, Unit } from "../units"
 import { localToViewSpace, localToWorldSpace } from "./spaces"
 import { Bool, Mat4, Vec2, Vec3 } from "./values"
 
+export const CameraPosition = Vec3($`cameraPosition`, {
+  name: "Camera Position"
+})
+
 export const ViewMatrix = Mat4($`viewMatrix`, {
-  name: "View Matrix",
-  only: "vertex"
+  name: "View Matrix"
 })
 
 export const ModelMatrix = Mat4($`modelMatrix`, {
-  name: "Model Matrix",
-  only: "vertex"
+  name: "Model Matrix"
 })
 
 export const ModelViewMatrix = Mat4($`modelViewMatrix`, {
-  name: "ModelView Matrix",
-  only: "vertex"
+  name: "ModelView Matrix"
+})
+
+export const NormalMatrix = Mat4($`normalMatrix`, {
+  name: "Normal Matrix"
+})
+
+export const ProjectionMatrix = Mat4($`projectionMatrix`, {
+  name: "Projection Matrix"
 })
 
 export const UsingInstancing = Bool($`

--- a/packages/shader-composer/src/stdlib/geometry.ts
+++ b/packages/shader-composer/src/stdlib/geometry.ts
@@ -19,6 +19,14 @@ export const ModelViewMatrix = Mat4($`modelViewMatrix`, {
   varying: true
 })
 
+export const UsingInstancing = Bool($`
+  #ifdef USE_INSTANCING
+    true
+  #else
+    false
+  #endif
+`)
+
 export const InstanceMatrix = Mat4(
   $`
     #ifdef USE_INSTANCING


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/keep-matrices-in-vertex-shader?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=keep-matrices-in-vertex-shader">VS Code</a>

<!-- open-in-codesandbox:complete -->

- Stops wrapping modelMatrix, viewMatrix etc. in varyings -- they're sourced from uniforms, so this has never been necessary.
- Marks `InstanceMatrix` as `only: "vertex"`, because we will never want to leak the entire matrix into the fragment shader.
- Improves error messages when a unit marked with `only` is used in the wrong program.