### PR TITLE
CSM Proxy

### DIFF
--- a/.changeset/serious-seahorses-exist.md
+++ b/.changeset/serious-seahorses-exist.md
@@ -1,0 +1,15 @@
+---
+"shader-composer-r3f": minor
+---
+
+Added a `<Custom.* />` component that wraps all the available Three.js materials (making use of the [three-custom-shader-material](https://github.com/FarazzShaikh/THREE-CustomShaderMaterial) library), making it super-easy to create instances of these materials using your custom shaders:
+
+```jsx
+<mesh castShadow receiveShadow>
+  <dodecahedronGeometry args={[2, 5]} />
+
+  <Custom.MeshStandardMaterial {...shader} flatShading metalness={0.5} roughness={0.5} />
+
+  <Custom.MeshDepthMaterial {...depthShader} />
+</mesh>
+```

--- a/apps/examples/src/examples/DiscoCube.tsx
+++ b/apps/examples/src/examples/DiscoCube.tsx
@@ -15,10 +15,9 @@ import {
   Time,
   VertexPosition
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { Custom, useShader } from "shader-composer-r3f"
 import { PSRDNoise3D } from "shader-composer-toybox"
-import { Color, Mesh, MeshPhysicalMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color, Mesh } from "three"
 
 export default function DiscoCube() {
   const mesh = useRef<Mesh>(null!)
@@ -57,11 +56,7 @@ export default function DiscoCube() {
       <Environment preset="city" />
       <mesh ref={mesh}>
         <boxGeometry args={[1.5, 1.5, 1.5]} />
-        <CustomShaderMaterial
-          baseMaterial={MeshPhysicalMaterial}
-          clearcoat={0.2}
-          {...shader}
-        />
+        <Custom.MeshPhysicalMaterial clearcoat={0.2} {...shader} />
       </mesh>
     </>
   )

--- a/apps/examples/src/examples/Dissolve.tsx
+++ b/apps/examples/src/examples/Dissolve.tsx
@@ -1,9 +1,8 @@
 import { useControls } from "leva"
 import { CustomShaderMaterialMaster, Mix, pipe } from "shader-composer"
-import { useShader, useUniformUnit } from "shader-composer-r3f"
+import { Custom, useShader, useUniformUnit } from "shader-composer-r3f"
 import { Dissolve } from "shader-composer-toybox"
-import { Color, DoubleSide, MeshPhysicalMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color, DoubleSide } from "three"
 
 export default function DissolveExample() {
   /* Leva */
@@ -40,8 +39,7 @@ export default function DissolveExample() {
   return (
     <mesh>
       <icosahedronGeometry args={[1, 10]} />
-      <CustomShaderMaterial
-        baseMaterial={MeshPhysicalMaterial}
+      <Custom.MeshPhysicalMaterial
         {...shader}
         transparent
         side={DoubleSide}

--- a/apps/examples/src/examples/Fireball.tsx
+++ b/apps/examples/src/examples/Fireball.tsx
@@ -14,10 +14,8 @@ import {
   VertexNormal,
   VertexPosition
 } from "shader-composer"
-import { useShader, useUniformUnit } from "shader-composer-r3f"
+import { Custom, useShader, useUniformUnit } from "shader-composer-r3f"
 import { PSRDNoise3D, Turbulence3D } from "shader-composer-toybox"
-import { MeshStandardMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
 import textureUrl from "./textures/explosion.png"
 
 export default function Fireball() {
@@ -82,7 +80,7 @@ export default function Fireball() {
   return (
     <mesh>
       <icosahedronGeometry args={[1, 5]} />
-      <CustomShaderMaterial baseMaterial={MeshStandardMaterial} {...shader} />
+      <Custom.MeshStandardMaterial {...shader} />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/Flag.tsx
+++ b/apps/examples/src/examples/Flag.tsx
@@ -1,43 +1,38 @@
 import { useTexture } from "@react-three/drei"
 import {
-	Add,
-	CustomShaderMaterialMaster,
-	Mul,
-	Sin,
-	Time,
-	UV,
-	vec3,
-	VertexPosition
+  Add,
+  CustomShaderMaterialMaster,
+  Mul,
+  Sin,
+  Time,
+  UV,
+  vec3,
+  VertexPosition
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { Custom, useShader } from "shader-composer-r3f"
 import { DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import textureUrl from "./textures/shader-composer-logo.jpg"
 
 export default function Flag() {
-	const texture = useTexture(textureUrl)
+  const texture = useTexture(textureUrl)
 
-	const shader = useShader(() => {
-		const time = Time()
+  const shader = useShader(() => {
+    const time = Time()
 
-		return CustomShaderMaterialMaster({
-			position: vec3(
-				VertexPosition.x,
-				VertexPosition.y,
-				Mul(Sin(Add(Mul(time, 2), Add(Mul(UV.y, 8), Mul(UV.x, 14)))), 0.2)
-			)
-		})
-	}, [])
+    return CustomShaderMaterialMaster({
+      position: vec3(
+        VertexPosition.x,
+        VertexPosition.y,
+        Mul(Sin(Add(Mul(time, 2), Add(Mul(UV.y, 8), Mul(UV.x, 14)))), 0.2)
+      )
+    })
+  }, [])
 
-	return (
-		<mesh>
-			<planeGeometry args={[4, 2, 40, 20]} />
-			<CustomShaderMaterial
-				baseMaterial={MeshStandardMaterial}
-				map={texture}
-				side={DoubleSide}
-				{...shader}
-			/>
-		</mesh>
-	)
+  return (
+    <mesh>
+      <planeGeometry args={[4, 2, 40, 20]} />
+      <Custom.MeshStandardMaterial map={texture} side={DoubleSide} {...shader} />
+    </mesh>
+  )
 }

--- a/apps/examples/src/examples/FloatingIsland.tsx
+++ b/apps/examples/src/examples/FloatingIsland.tsx
@@ -24,15 +24,9 @@ import {
   Vec3,
   vec3
 } from "shader-composer"
-import {
-  Custom,
-  CustomDepthMaterial,
-  useShader,
-  useUniformUnit
-} from "shader-composer-r3f"
+import { Custom, useShader, useUniformUnit } from "shader-composer-r3f"
 import { Displacement, PSRDNoise2D } from "shader-composer-toybox"
-import { Color, MeshStandardMaterial, Vector2 } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color, Vector2 } from "three"
 
 export default function FloatingIslandExample() {
   return (

--- a/apps/examples/src/examples/FloatingIsland.tsx
+++ b/apps/examples/src/examples/FloatingIsland.tsx
@@ -1,7 +1,6 @@
 import { Environment, Float as Floating } from "@react-three/drei"
 import { useControls } from "leva"
 import { FlatStage } from "r3f-stage"
-import { useCallback } from "react"
 import {
   Add,
   CustomShaderMaterialMaster,
@@ -56,10 +55,11 @@ const FloatingIsland = () => {
     })
   }
 
-  /* A helper function that will generate some powered and scaled noise for us,
-  taking into account the offset currently configured by the user. */
-  const noise = useCallback(
-    (
+  /* Let's create the shader itself! */
+  const shader = useShader(() => {
+    /* A helper function that will generate some powered and scaled noise for us,
+    taking into account the offset currently configured by the user. */
+    const noise = (
       v: Input<"vec2">,
       scale: Input<"float"> = 1,
       height: Input<"float"> = 1,
@@ -70,35 +70,31 @@ const FloatingIsland = () => {
         (v) => NormalizePlusMinusOne(v),
         (v) => Pow(v, pow),
         (v) => Mul(v, height)
-      ),
-    []
-  )
+      )
 
-  /* Set up a displacement function. It takes the existing position of a vertex and
-  modifies it according to our rules. */
-  const displace = useCallback((v: Unit<"vec3">) => {
-    const xz = vec2(v.x, v.z)
+    /* Set up a displacement function. It takes the existing position of a vertex and
+    modifies it according to our rules. */
+    const displace = (v: Unit<"vec3">) => {
+      const xz = vec2(v.x, v.z)
 
-    const height = pipe(
-      Float(0.2),
-      (v) => Sub(v, noise(xz, 0.5, 0.2)),
-      (v) => Add(v, noise(xz, 0.2, 1)),
-      (v) => Add(v, noise(xz, 1, 2, 3)),
-      (v) => Mul(v, Smoothstep(2, 0.5, Length(xz)))
-    )
+      const height = pipe(
+        Float(0.2),
+        (v) => Sub(v, noise(xz, 0.5, 0.2)),
+        (v) => Add(v, noise(xz, 0.2, 1)),
+        (v) => Add(v, noise(xz, 1, 2, 3)),
+        (v) => Mul(v, Smoothstep(2, 0.5, Length(xz)))
+      )
 
-    /* Displacement for the upper half of the island. */
-    const displaceUpper = vec3(v.x, height, v.z)
+      /* Displacement for the upper half of the island. */
+      const displaceUpper = vec3(v.x, height, v.z)
 
-    /* Displacement for the lower half of the island. */
-    const displaceLower = vec3(v.x, Mul(v.y, 0.7), v.z)
+      /* Displacement for the lower half of the island. */
+      const displaceLower = vec3(v.x, Mul(v.y, 0.7), v.z)
 
-    /* Displacement for the entire island. */
-    return If(GreaterOrEqual(v.y, 0), displaceUpper, displaceLower)
-  }, [])
+      /* Displacement for the entire island. */
+      return If(GreaterOrEqual(v.y, 0), displaceUpper, displaceLower)
+    }
 
-  /* Let's create the shader itself! */
-  const shader = useShader(() => {
     /* Let's displace some vertices! We'll also wrap the position in a
     varying. If we don't do this, the fragment shader will end up
     recalculating the position for every fragment. */
@@ -120,14 +116,6 @@ const FloatingIsland = () => {
     })
   }, [])
 
-  /* Let's create another shader that _only_ performs the vertex displacement.
-  We'll use it in a custom depth material that will help us get correct shadows. */
-  const depthShader = useShader(() => {
-    return CustomShaderMaterialMaster({
-      position: Displacement(displace).position
-    })
-  }, [])
-
   return (
     <mesh castShadow receiveShadow>
       <dodecahedronGeometry args={[2, 5]} />
@@ -139,7 +127,11 @@ const FloatingIsland = () => {
         roughness={0.5}
       />
 
-      <Custom.MeshDepthMaterial {...depthShader} />
+      {/* We don't need the fragment shader in the depth material. */}
+      <Custom.MeshDepthMaterial
+        vertexShader={shader.vertexShader}
+        uniforms={shader.uniforms}
+      />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/FloatingIsland.tsx
+++ b/apps/examples/src/examples/FloatingIsland.tsx
@@ -24,7 +24,12 @@ import {
   Vec3,
   vec3
 } from "shader-composer"
-import { CustomDepthMaterial, useShader, useUniformUnit } from "shader-composer-r3f"
+import {
+  Custom,
+  CustomDepthMaterial,
+  useShader,
+  useUniformUnit
+} from "shader-composer-r3f"
 import { Displacement, PSRDNoise2D } from "shader-composer-toybox"
 import { Color, MeshStandardMaterial, Vector2 } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
@@ -132,8 +137,15 @@ const FloatingIsland = () => {
   return (
     <mesh castShadow receiveShadow>
       <dodecahedronGeometry args={[2, 5]} />
-      <CustomShaderMaterial baseMaterial={MeshStandardMaterial} {...shader} flatShading />
-      <CustomDepthMaterial {...depthShader} />
+
+      <Custom.MeshStandardMaterial
+        {...shader}
+        flatShading
+        metalness={0.5}
+        roughness={0.5}
+      />
+
+      <Custom.MeshDepthMaterial {...depthShader} />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/ForceField.tsx
+++ b/apps/examples/src/examples/ForceField.tsx
@@ -21,9 +21,8 @@ import {
   vec2,
   VertexPosition
 } from "shader-composer"
-import { useShader, useUniformUnit } from "shader-composer-r3f"
-import { Color, MeshStandardMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Custom, useShader, useUniformUnit } from "shader-composer-r3f"
+import { Color } from "three"
 import { useRepeatingTexture } from "./helpers"
 
 export default function ForceField() {
@@ -82,13 +81,7 @@ export default function ForceField() {
       <Float floatIntensity={1} speed={2}>
         <mesh layers-mask={Layers.TransparentFX}>
           <icosahedronGeometry args={[1.3, 8]} />
-
-          <CustomShaderMaterial
-            baseMaterial={MeshStandardMaterial}
-            transparent
-            depthWrite={false}
-            {...shader}
-          />
+          <Custom.MeshStandardMaterial transparent depthWrite={false} {...shader} />
         </mesh>
 
         <pointLight

--- a/apps/examples/src/examples/Planet.tsx
+++ b/apps/examples/src/examples/Planet.tsx
@@ -1,139 +1,133 @@
 import {
-	Add,
-	Clamp,
-	CustomShaderMaterialMaster,
-	Float,
-	Fresnel,
-	Input,
-	Mix,
-	Mul,
-	pipe,
-	Sin,
-	Smoothstep,
-	SplitVector3,
-	Step,
-	Time,
-	Vec3,
-	VertexPosition
+  Add,
+  Clamp,
+  CustomShaderMaterialMaster,
+  Float,
+  Fresnel,
+  Input,
+  Mix,
+  Mul,
+  pipe,
+  Sin,
+  Smoothstep,
+  SplitVector3,
+  Step,
+  Time,
+  Vec3,
+  VertexPosition
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { Custom, useShader } from "shader-composer-r3f"
 import { Simplex3DNoise } from "shader-composer-toybox"
-import { Color, MeshStandardMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color } from "three"
 
 const getNoise = (
-	scale: number,
-	amplitude: number,
-	offset: Input<"float" | "vec3"> = 0
+  scale: number,
+  amplitude: number,
+  offset: Input<"float" | "vec3"> = 0
 ) =>
-	pipe(
-		VertexPosition,
-		(v) => Mul(v, scale),
-		(v) => Add(v, Add(offset, Math.random() * 100)),
-		(v) => Simplex3DNoise(v),
-		(v) => Mul(v, amplitude)
-	)
+  pipe(
+    VertexPosition,
+    (v) => Mul(v, scale),
+    (v) => Add(v, Add(offset, Math.random() * 100)),
+    (v) => Simplex3DNoise(v),
+    (v) => Mul(v, amplitude)
+  )
 
 function Planet() {
-	const shader = useShader(() => {
-		const continents = getNoise(1, 0.1)
-		const hills = getNoise(0.8, 0.2)
-		const mountains = getNoise(1.2, 0.2)
+  const shader = useShader(() => {
+    const continents = getNoise(1, 0.1)
+    const hills = getNoise(0.8, 0.2)
+    const mountains = getNoise(1.2, 0.2)
 
-		const totalHeight = pipe(
-			continents,
-			(v) => Add(v, hills),
-			(v) => Add(v, mountains),
-			(v) => Clamp(v, 0, 1)
-		)
+    const totalHeight = pipe(
+      continents,
+      (v) => Add(v, hills),
+      (v) => Add(v, mountains),
+      (v) => Clamp(v, 0, 1)
+    )
 
-		const water = pipe(
-			Time(),
-			(v) => Add(v, SplitVector3(VertexPosition)[1]),
-			(v) => Sin(v),
-			(v) => Mul(v, 0.008),
-			(v) => Add(v, 0.02)
-		)
+    const water = pipe(
+      Time(),
+      (v) => Add(v, SplitVector3(VertexPosition)[1]),
+      (v) => Sin(v),
+      (v) => Mul(v, 0.008),
+      (v) => Add(v, 0.02)
+    )
 
-		const applyColor = (color: Color, height: Input<"float">) => (v: Input<"vec3">) =>
-			Mix(v, color, Step(height, totalHeight))
+    const applyColor = (color: Color, height: Input<"float">) => (v: Input<"vec3">) =>
+      Mix(v, color, Step(height, totalHeight))
 
-		return CustomShaderMaterialMaster({
-			position: pipe(
-				totalHeight,
-				(v) => Add(1.0, v),
-				(v) => Mul(VertexPosition, v)
-			),
+    return CustomShaderMaterialMaster({
+      position: pipe(
+        totalHeight,
+        (v) => Add(1.0, v),
+        (v) => Mul(VertexPosition, v)
+      ),
 
-			diffuseColor: pipe(
-				Vec3(new Color("#336")),
-				applyColor(new Color("yellow"), water),
-				applyColor(new Color("#484"), 0.04),
-				applyColor(new Color("#262"), 0.1),
-				applyColor(new Color("#444"), 0.2),
-				applyColor(new Color("#555"), 0.25),
-				applyColor(new Color("#fff"), 0.3)
-			)
-		})
-	})
+      diffuseColor: pipe(
+        Vec3(new Color("#336")),
+        applyColor(new Color("yellow"), water),
+        applyColor(new Color("#484"), 0.04),
+        applyColor(new Color("#262"), 0.1),
+        applyColor(new Color("#444"), 0.2),
+        applyColor(new Color("#555"), 0.25),
+        applyColor(new Color("#fff"), 0.3)
+      )
+    })
+  })
 
-	return (
-		<mesh>
-			<icosahedronGeometry args={[1, 12]} />
-			<CustomShaderMaterial baseMaterial={MeshStandardMaterial} {...shader} />
-		</mesh>
-	)
+  return (
+    <mesh>
+      <icosahedronGeometry args={[1, 12]} />
+      <Custom.MeshStandardMaterial {...shader} />
+    </mesh>
+  )
 }
 
 function Atmosphere() {
-	const shader = useShader(() => {
-		const time = Time()
+  const shader = useShader(() => {
+    const time = Time()
 
-		const cloudSpeed = 0.02
-		const cloudThreshold = 0.5
-		const cloudDensity = 0.9
-		const atmosphereDensity = 0.05
+    const cloudSpeed = 0.02
+    const cloudThreshold = 0.5
+    const cloudDensity = 0.9
+    const atmosphereDensity = 0.05
 
-		const cloudNoise = Add(
-			getNoise(0.5, 1, Mul(time, cloudSpeed)),
-			getNoise(0.2, 1, Mul(time, cloudSpeed * -0.5))
-		)
+    const cloudNoise = Add(
+      getNoise(0.5, 1, Mul(time, cloudSpeed)),
+      getNoise(0.2, 1, Mul(time, cloudSpeed * -0.5))
+    )
 
-		const clouds = pipe(
-			cloudNoise,
-			(v) => Smoothstep(cloudThreshold, cloudThreshold + 0.08, v),
-			(v) => Mul(v, cloudDensity)
-		)
+    const clouds = pipe(
+      cloudNoise,
+      (v) => Smoothstep(cloudThreshold, cloudThreshold + 0.08, v),
+      (v) => Mul(v, cloudDensity)
+    )
 
-		const fresnel = Mul(Fresnel(), 0.3)
+    const fresnel = Mul(Fresnel(), 0.3)
 
-		return CustomShaderMaterialMaster({
-			alpha: pipe(
-				Float(atmosphereDensity),
-				(v) => Add(v, clouds),
-				(v) => Add(v, fresnel)
-			)
-		})
-	})
+    return CustomShaderMaterialMaster({
+      alpha: pipe(
+        Float(atmosphereDensity),
+        (v) => Add(v, clouds),
+        (v) => Add(v, fresnel)
+      )
+    })
+  })
 
-	return (
-		<mesh>
-			<icosahedronGeometry args={[1.15, 12]} />
-			<CustomShaderMaterial
-				baseMaterial={MeshStandardMaterial}
-				color="white"
-				{...shader}
-				transparent
-			/>
-		</mesh>
-	)
+  return (
+    <mesh>
+      <icosahedronGeometry args={[1.15, 12]} />
+      <Custom.MeshStandardMaterial color="white" {...shader} transparent />
+    </mesh>
+  )
 }
 
 export default function() {
-	return (
-		<>
-			<Planet />
-			<Atmosphere />
-		</>
-	)
+  return (
+    <>
+      <Planet />
+      <Atmosphere />
+    </>
+  )
 }

--- a/apps/examples/src/examples/Rotation.tsx
+++ b/apps/examples/src/examples/Rotation.tsx
@@ -6,9 +6,8 @@ import {
   VertexNormal,
   VertexPosition
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
-import { MeshStandardMaterial, Vector3 } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Custom, useShader } from "shader-composer-r3f"
+import { Vector3 } from "three"
 
 export default function MatrixTransformations() {
   const shader = useShader(() => {
@@ -27,11 +26,7 @@ export default function MatrixTransformations() {
   return (
     <mesh>
       <boxGeometry />
-      <CustomShaderMaterial
-        baseMaterial={MeshStandardMaterial}
-        color="orange"
-        {...shader}
-      />
+      <Custom.MeshStandardMaterial color="orange" {...shader} />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/StylizedWater.tsx
+++ b/apps/examples/src/examples/StylizedWater.tsx
@@ -23,10 +23,9 @@ import {
   VertexNormal,
   VertexPosition
 } from "shader-composer"
-import { useShader, useUniformUnit } from "shader-composer-r3f"
+import { Custom, useShader, useUniformUnit } from "shader-composer-r3f"
 import { PSRDNoise2D, PSRDNoise3D } from "shader-composer-toybox"
-import { Color, MeshStandardMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color } from "three"
 
 export default function StylizedWater() {
   return (
@@ -163,12 +162,7 @@ const Water = (props: MeshProps) => {
   return (
     <mesh {...props} layers-mask={Layers.TransparentFX} rotation-x={-Math.PI / 2}>
       <planeGeometry args={[100, 100, 137, 137]} />
-      <CustomShaderMaterial
-        baseMaterial={MeshStandardMaterial}
-        metalness={0.5}
-        roughness={0.1}
-        {...shader}
-      />
+      <Custom.MeshStandardMaterial metalness={0.5} roughness={0.1} {...shader} />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/Textures.tsx
+++ b/apps/examples/src/examples/Textures.tsx
@@ -11,9 +11,8 @@ import {
   UV,
   vec2
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
-import { Color, MeshStandardMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Custom, useShader } from "shader-composer-r3f"
+import { Color } from "three"
 import { useRepeatingTexture } from "./helpers"
 
 export default function Textures() {
@@ -40,7 +39,7 @@ export default function Textures() {
   return (
     <mesh>
       <icosahedronGeometry args={[1, 3]} />
-      <CustomShaderMaterial baseMaterial={MeshStandardMaterial} {...shader} transparent />
+      <Custom.MeshStandardMaterial {...shader} transparent />
     </mesh>
   )
 }

--- a/apps/examples/src/examples/Water.tsx
+++ b/apps/examples/src/examples/Water.tsx
@@ -11,10 +11,9 @@ import {
   Time,
   vec2
 } from "shader-composer"
-import { useShader } from "shader-composer-r3f"
+import { Custom, useShader } from "shader-composer-r3f"
 import { Displacement, FBMNoise, GerstnerWave } from "shader-composer-toybox"
-import { Color, DoubleSide, MeshPhysicalMaterial } from "three"
-import CustomShaderMaterial from "three-custom-shader-material"
+import { Color, DoubleSide } from "three"
 
 const NormalizeNoise = (v: Input<"float">) => Remap(v, -1, 1, 0, 1)
 
@@ -66,8 +65,7 @@ function Water() {
   return (
     <mesh position-y={-12}>
       <boxGeometry args={[70, 16, 70, 120, 1, 120]} />
-      <CustomShaderMaterial
-        baseMaterial={MeshPhysicalMaterial}
+      <Custom.MeshPhysicalMaterial
         {...shader}
         roughness={0.1}
         metalness={0.5}

--- a/apps/examples/src/examples/index.tsx
+++ b/apps/examples/src/examples/index.tsx
@@ -60,8 +60,7 @@ const examples: Examples = {
         This example demonstrates <strong>vertex displacement</strong> and{" "}
         <strong>applying colors based on displaced vertex positions</strong>. It also
         shows you how to customize the mesh's <strong>depth material</strong> (which is
-        needed for proper shadows), and how to{" "}
-        <strong>reuse parts of the shader graph</strong> in multiple shaders.
+        needed for proper shadows).
       </p>
     ),
     Example: lazy(() => import("./FloatingIsland"))

--- a/packages/shader-composer-r3f/src/materials.tsx
+++ b/packages/shader-composer-r3f/src/materials.tsx
@@ -1,5 +1,5 @@
 import { Node } from "@react-three/fiber"
-import React, { forwardRef, useState } from "react"
+import React, { forwardRef } from "react"
 import {
   IUniform,
   MeshBasicMaterial,
@@ -14,28 +14,8 @@ import {
   MeshToonMaterial,
   RGBADepthPacking
 } from "three"
-import CustomShaderMaterial, { iCSMProps } from "three-custom-shader-material"
+import CustomShaderMaterial from "three-custom-shader-material"
 import CustomShaderMaterialImpl from "three-custom-shader-material/vanilla"
-
-export type CustomDepthMaterialProps = Omit<iCSMProps, "ref" | "baseMaterial">
-
-export const CustomDepthMaterial = forwardRef<
-  CustomShaderMaterialImpl,
-  CustomDepthMaterialProps
->((props, ref) => {
-  const [material] = useState(
-    () => new MeshDepthMaterial({ depthPacking: RGBADepthPacking })
-  )
-
-  return (
-    <CustomShaderMaterial
-      ref={ref}
-      attach="customDepthMaterial"
-      baseMaterial={material}
-      {...props}
-    />
-  )
-})
 
 export type MaterialConstructor<T extends THREE.Material> = { new (...args: any[]): T }
 

--- a/packages/shader-composer-r3f/src/materials.tsx
+++ b/packages/shader-composer-r3f/src/materials.tsx
@@ -34,6 +34,9 @@ const makeMaterialComponent = <T extends THREE.Material>(ctor: {
   new (...args: any[]): T
 }) =>
   forwardRef<CustomShaderMaterialImpl, Node<T, typeof ctor>>((props, ref) => {
+    /* We still need to ts-ignore the next line, because something between
+    R3F's and CSM's props typings appears to be deeply incompatible. */
+
     // @ts-ignore
     return <CustomShaderMaterial baseMaterial={ctor} {...props} ref={ref} />
   })

--- a/packages/shader-composer-r3f/src/materials.tsx
+++ b/packages/shader-composer-r3f/src/materials.tsx
@@ -1,7 +1,14 @@
 import React, { forwardRef, useState } from "react"
 import CustomShaderMaterial, { iCSMProps } from "three-custom-shader-material"
 import CustomShaderMaterialImpl from "three-custom-shader-material/vanilla"
-import { MeshDepthMaterial, RGBADepthPacking } from "three"
+import {
+  Material,
+  MeshBasicMaterial,
+  MeshDepthMaterial,
+  MeshStandardMaterial,
+  RGBADepthPacking
+} from "three"
+import { Node, NodeProps } from "@react-three/fiber"
 
 export type CustomDepthMaterialProps = Omit<iCSMProps, "ref" | "baseMaterial">
 
@@ -22,3 +29,16 @@ export const CustomDepthMaterial = forwardRef<
     />
   )
 })
+
+const makeMaterialComponent = <T extends THREE.Material>(ctor: {
+  new (...args: any[]): T
+}) =>
+  forwardRef<CustomShaderMaterialImpl, Node<T, typeof ctor>>((props, ref) => {
+    // @ts-ignore
+    return <CustomShaderMaterial baseMaterial={ctor} {...props} ref={ref} />
+  })
+
+export const Custom = {
+  MeshStandardMaterial: makeMaterialComponent(MeshStandardMaterial),
+  MeshBasicMaterial: makeMaterialComponent(MeshBasicMaterial)
+}


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/custom-materials-proxy?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=custom-materials-proxy">VS Code</a>

<!-- open-in-codesandbox:complete -->


Adds a proxy that wraps CSM and provides more accurate types