### PR TITLE
CSMMaster: only write roughness and metalness in shaders that support it.

### DIFF
--- a/.changeset/bright-kings-enjoy.md
+++ b/.changeset/bright-kings-enjoy.md
@@ -1,0 +1,5 @@
+---
+"shader-composer": patch
+---
+
+In `CustomShaderMaterialMaster`, only write to `csm_Roughness` and `csm_Metalness` when the shader is used within a MeshStandardMaterial or MeshPhysicalMaterial.

--- a/packages/shader-composer/src/stdlib/masters.ts
+++ b/packages/shader-composer/src/stdlib/masters.ts
@@ -69,14 +69,10 @@ export const CustomShaderMaterialMaster = ({
 				${emissiveColor !== undefined ? $`csm_Emissive = ${emissiveColor};` : ""}
 				${fragColor !== undefined ? $`csm_FragColor = vec4(${fragColor}, ${alpha});` : ""}
 
-				/* Mix in the texture. This may be obsolete with a future update to CSM. */
-        #ifdef USE_MAP
-          csm_DiffuseColor *= texture2D(map, vUv);
+        #if defined IS_MESHSTANDARDMATERIAL || defined IS_MESHPHYSICALMATERIAL
+          ${roughness !== undefined ? $`csm_Roughness = ${roughness};` : ""}
+          ${metalness !== undefined ? $`csm_Metalness = ${metalness};` : ""}
         #endif
-
-				${roughness !== undefined ? $`csm_Roughness = ${roughness};` : ""}
-				${metalness !== undefined ? $`csm_Metalness = ${metalness};` : ""}
-
-				`
+			`
     }
   })


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/shader-composer/better-support-for-csm-variables?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=shader-composer&branch=better-support-for-csm-variables">VS Code</a>

<!-- open-in-codesandbox:complete -->


Followup for later: hmans/composer-suite#201