### PR TITLE
Fix `Billboard`

### DIFF
--- a/.changeset/popular-donuts-judge.md
+++ b/.changeset/popular-donuts-judge.md
@@ -1,0 +1,5 @@
+---
+"shader-composer-toybox": patch
+---
+
+`Billboard` now correctly billboards rotated meshes.

--- a/.changeset/slow-hats-cross.md
+++ b/.changeset/slow-hats-cross.md
@@ -1,0 +1,5 @@
+---
+"shader-composer-toybox": patch
+---
+
+Fixed a bug where `Billboard` would crash when used outside of instanced rendering.

--- a/apps/examples/src/App.tsx
+++ b/apps/examples/src/App.tsx
@@ -1,5 +1,6 @@
 import { Application, Description, Example, Heading } from "r3f-stage"
 import "r3f-stage/styles.css"
+import BillboardingExample from "./examples/Billboarding"
 import DiscoCube from "./examples/DiscoCube"
 import DissolveExample from "./examples/Dissolve"
 import Fireball from "./examples/Fireball"
@@ -17,6 +18,7 @@ function App() {
   return (
     <Application>
       <Heading>The Basics</Heading>
+
       <Example path="hello-world" title="Hello World" makeDefault>
         <Description>
           A simple example demonstrating <strong>color changes</strong>,{" "}
@@ -24,6 +26,12 @@ function App() {
         </Description>
 
         <HelloWorld />
+      </Example>
+
+      <Heading>Techniques</Heading>
+
+      <Example path="billboarding" title="Billboarding">
+        <BillboardingExample />
       </Example>
 
       <Example path="rotation" title="Rotation (Vertex Displacement)">

--- a/apps/examples/src/examples/Billboarding.tsx
+++ b/apps/examples/src/examples/Billboarding.tsx
@@ -1,3 +1,23 @@
+import { FlatStage } from "r3f-stage"
+import { ShaderMaterialMaster, VertexPosition } from "shader-composer"
+import { useShader } from "shader-composer-r3f"
+import { Billboard } from "shader-composer-toybox"
+import { Color } from "three"
+
 export default function BillboardingExample() {
-  return null
+  const shader = useShader(() => {
+    return ShaderMaterialMaster({
+      position: Billboard(VertexPosition),
+      color: new Color("hotpink")
+    })
+  })
+
+  return (
+    <FlatStage>
+      <mesh position-y={1.5}>
+        <planeGeometry />
+        <shaderMaterial {...shader} />
+      </mesh>
+    </FlatStage>
+  )
 }

--- a/apps/examples/src/examples/Billboarding.tsx
+++ b/apps/examples/src/examples/Billboarding.tsx
@@ -1,4 +1,4 @@
-import { FlatStage } from "r3f-stage"
+import { Description, FlatStage } from "r3f-stage"
 import { ShaderMaterialMaster, VertexPosition } from "shader-composer"
 import { useShader } from "shader-composer-r3f"
 import { Billboard } from "shader-composer-toybox"
@@ -14,10 +14,16 @@ export default function BillboardingExample() {
 
   return (
     <FlatStage>
-      <mesh position-y={1.5}>
+      {/* Intentionally rotating the mesh to prove that billboarding will negate this transform. */}
+      <mesh position={[2, 1.5, 0]} rotation-y={0.5}>
         <planeGeometry />
         <shaderMaterial {...shader} />
       </mesh>
+
+      <Description>
+        Use the <strong>Billboard</strong> unit to turn a mesh (like this plane) into a
+        billboard that is always facing the camera.
+      </Description>
     </FlatStage>
   )
 }

--- a/apps/examples/src/examples/Billboarding.tsx
+++ b/apps/examples/src/examples/Billboarding.tsx
@@ -1,0 +1,3 @@
+export default function BillboardingExample() {
+  return null
+}

--- a/packages/shader-composer-toybox/src/tools/Billboard.ts
+++ b/packages/shader-composer-toybox/src/tools/Billboard.ts
@@ -15,6 +15,6 @@ export const Billboard = (position: Input<"vec3">) =>
   Vec3($`${billboard}(${position}.xy,
     ${ViewMatrix}
     #ifdef USE_INSTANCING
-    * ${InstanceMatrix}
+    * instanceMatrix
     #endif
     )`)

--- a/packages/shader-composer-toybox/src/tools/Billboard.ts
+++ b/packages/shader-composer-toybox/src/tools/Billboard.ts
@@ -1,4 +1,4 @@
-import { Snippet, Input, Vec3, ViewMatrix, InstanceMatrix, $ } from "shader-composer"
+import { $, Input, ModelMatrix, Snippet, Vec3, ViewMatrix } from "shader-composer"
 
 const billboard = Snippet(
   (name) => $`
@@ -14,6 +14,7 @@ const billboard = Snippet(
 export const Billboard = (position: Input<"vec3">) =>
   Vec3($`${billboard}(${position}.xy,
     ${ViewMatrix}
+    * ${ModelMatrix}
     #ifdef USE_INSTANCING
     * instanceMatrix
     #endif


### PR DESCRIPTION
- Fixes where `Billboard` got confused when the mesh was rotated
- Fixes a bug where `Billboard` was always pulling in a dependency to `instanceMatrix`, making it crash outside of instanced rendering